### PR TITLE
Update gen_protos.sh for better compatability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ compiler to identify all callsites that may need to be visited. However, it can 
 many callsites a bit tedious. We opted to go this route to make it easier to add a new field and update
 all callsites with assistance from the compiler.
 
+# Installation
+
+1. Clone Repo
+2. Install Dependencies
+	a. protoc
+		On OSX `brew install protobuf`
+	b. gogoproto
+		If you don't have go `brew install go`
+		`go get github.com/gogo/protobuf/proto`
+	c. python & dependencies
+		`brew install python3`
+		`pip install six`
+		`pip install protobuf`
+3. `cargo test`
+
+
 ### TODO - before open sourcing
 
 - [x] Get onto github


### PR DESCRIPTION
Some basic improvements to gen_protos.sh plus adds some basic
install instructions to the README.

gen_protos.sh updates inlcude:
- Adds shebang
- Uses default GOPATH if one isn't set
- Tries to use readlink -f to determine protobuf install path
  falls back to realpath if readlink doesn't exist.
  [Note: this is not great. readlink -f works most places but
   not on OSX. with a `brew install coreutils` OSX gets greadlink
   which supports the -f flag and realpath which does the same
   thing. I spent a bunch of time trying to write a more portable
   realpath type sh script, but gave up. I think since we already
   require python we should just write this script in python.]