### PR TITLE
[proto3] Migrate extensions and servicepb to proto3

### DIFF
--- a/proto/pbtest/servicepb.proto
+++ b/proto/pbtest/servicepb.proto
@@ -1,13 +1,13 @@
-syntax="proto2";
+syntax="proto3";
 
 package pbtest;
 
 message InpMessage {
-   optional int32 i = 1;
+    int32 i = 1;
 }
 
 message OutMessage {
-   optional int32 o = 1;
+    int32 o = 1;
 }
 
 service TestService {

--- a/proto/rust/extensions.proto
+++ b/proto/rust/extensions.proto
@@ -1,3 +1,10 @@
+// Protocol Buffers for Rust with Gadgets
+//
+// Note: While proto3 still supports extensions for custom fields (https://github.com/protocolbuffers/protobuf/issues/1460)
+// it does not support default values. Unfortunately the OneOfOptions::nullable field has a default value of true, while
+// in proto3 booleans have a default value of false. We can't migrate this file to proto3 without deprecating nullable
+// and changing its semantics. gogoproto extensions still use proto2 as well (https://github.com/gogo/protobuf/blob/master/gogoproto/gogo.proto)
+
 syntax = "proto2";
 package rust;
 


### PR DESCRIPTION
This change migrates `servicepb.proto` to proto3. I also investigated migrating `extensions.proto` to proto3, but I don't think its possible because of the `nullable` option for `OneOf`s having a default value of `true`, and proto3 doesn't support setting default values. If there are work arounds for this though, would be more than happy to implement them