### PR TITLE
Add README to Cargo.toml for pb-jelly

### DIFF
--- a/pb-jelly/Cargo.toml
+++ b/pb-jelly/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license-file = "LICENSE"
 homepage = "https://github.com/dropbox/pb-rs"
 repository = "https://github.com/dropbox/pb-rs"
+readme = "README.md"
 keywords = ["google", "protobuf", "proto", "dropbox"]
 categories = ["encoding", "parsing", "web-programming"]
 


### PR DESCRIPTION
Forgot to initially add the README, this allows it to show up crates.io