### PR TITLE
Cargo.toml related housekeeping and bump the version to v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v0.0.2
+### September 19, 2020
+* Use the `license` field instead of the `license-file` field in the Cargo.toml of `pb-jelly` and `pb-jelly-gen`. 
+    * Note: The License is still the same, the update is purely for better metadata from [crates.io](https://crates.io/crates/pb-jelly)
+* Warn on `rust_2018_idioms` closes [#45](https://github.com/dropbox/pb-jelly/issues/45)
+* A few changes related solely to re-integrating `pb-jelly` into the Dropbox codebase.

--- a/pb-jelly-gen/Cargo.toml
+++ b/pb-jelly-gen/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pb-jelly-gen"
 description = "A protobuf binding generation framework for the Rust language developed at Dropbox"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
-license-file = "LICENSE"
-homepage = "https://github.com/dropbox/pb-rs"
-repository = "https://github.com/dropbox/pb-rs"
+license = "Apache-2.0"
+homepage = "https://github.com/dropbox/pb-jelly"
+repository = "https://github.com/dropbox/pb-jelly/tree/master/pb-jelly-gen"
 readme = "README.md"
 keywords = ["google", "protobuf", "proto", "dropbox"]
 categories = ["encoding", "parsing", "web-programming"]

--- a/pb-jelly/Cargo.toml
+++ b/pb-jelly/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pb-jelly"
 description = "A protobuf runtime for the Rust language developed at Dropbox"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
-license-file = "LICENSE"
-homepage = "https://github.com/dropbox/pb-rs"
-repository = "https://github.com/dropbox/pb-rs"
+license = "Apache-2.0"
+homepage = "https://github.com/dropbox/pb-jelly"
+repository = "https://github.com/dropbox/pb-jelly/tree/master/pb-jelly"
 readme = "README.md"
 keywords = ["google", "protobuf", "proto", "dropbox"]
 categories = ["encoding", "parsing", "web-programming"]


### PR DESCRIPTION
Updating the `Cargo.toml`s for `pb-jelly` and `pb-jelly-gen` to point to the renamed repo, but also to use `license = "Apache-2.0"` instead of `license-file` because the former shows up in crates.io as "Apache 2.0" but the later shows up as "non standard"