### PR TITLE
A bazel rust_doc rule to generated bazel BUILD files

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1661,6 +1661,12 @@ rust_library(
     name = "{crate}",
     crate_type = "lib",
 )
+
+
+rust_doc(
+    name = "{crate}_doc",
+    crate = ":{crate}",
+)
 """
 
 SPEC_TOML_TEMPLATE = (


### PR DESCRIPTION
This PR merges in `D691936`, which was committed to the codegen script after we made this repo, but before we re-merged it with the DBX codebase. For every crate, when we generate a bazel BUILD file, it adds the `rust_doc` bazel rule