### PR TITLE
Update `codegen.py` to use `pb-jelly` 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# 0.0.3
+### September 21, 2020
+* Forgot to bump the version of `pb-jelly` that the codegen script uses
+
 # v0.0.2
 ### September 19, 2020
-* Use the `license` field instead of the `license-file` field in the Cargo.toml of `pb-jelly` and `pb-jelly-gen`. 
+* Use the `license` field instead of the `license-file` field in the Cargo.toml of `pb-jelly` and `pb-jelly-gen`.
     * Note: The License is still the same, the update is purely for better metadata from [crates.io](https://crates.io/crates/pb-jelly)
 * Warn on `rust_2018_idioms` closes [#45](https://github.com/dropbox/pb-jelly/issues/45)
 * A few changes related solely to re-integrating `pb-jelly` into the Dropbox codebase.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Multiple crates, multiple languages, my oh my!
 ### Essential Crates
 There are only two crates you'll need if you want to use this with you project `pb-jelly` and `pb-jelly-gen`. <br />
 
-##### `pb-jelly` 
+##### `pb-jelly`
 Contains all of the important traits and structs that power our generated code, e.g. `Message` and `Lazy`. Include this as a `dependency`, e.g.
 ```
 [dependencies]
-pb-jelly = "0.0.1"
+pb-jelly = "0.0.3"
 ```
 
-##### `pb-jelly-gen` 
+##### `pb-jelly-gen`
 
 A framework for generating Rust structs and implementations for `proto2` and `proto3` files.
 In order to use pb-jelly, you need to add the pb-jelly-gen/codegen/codegen.py as a plugin to your protoc invocation.
@@ -74,7 +74,7 @@ You'll need to add a generation crate (see `examples_gen` for an example)
 Include `pb-jelly-gen` as a dependency of your generation crate, and `cargo run` to invoke protoc for you.
 ```
 [dependencies]
-pb-jelly-gen = "0.0.1"
+pb-jelly-gen = "0.0.3"
 ```
 
 Eventually, we hope to eliminate the need for a generation crate, and simply have generation occur
@@ -116,7 +116,7 @@ We also like [the popular sandwich](https://en.wikipedia.org/wiki/Peanut_butter_
 
 # Contributing
 
-First, contributions are __greatly__ appreciated and highly encouraged. For legal reasons all outside 
+First, contributions are __greatly__ appreciated and highly encouraged. For legal reasons all outside
 contributors must agree to [Dropbox's CLA](https://opensource.dropbox.com/cla/). Thank you for
 your understanding.
 
@@ -146,12 +146,12 @@ Service Generation
 1. Clone Repo.
 2. Install Dependencies / Testing Dependencies. These instructions are for OSX using the brew
    package manager. Use the appropriate package manager for your system.
-    - protoc - part of Google's [protobuf tools](https://github.com/protocolbuffers/protobuf/)	
+    - protoc - part of Google's [protobuf tools](https://github.com/protocolbuffers/protobuf/)
         - `brew install protobuf`
     - Install Go
         - `brew install go`
     - Install [gogoproto](https://github.com/gogo/protobuf)
-        - `go get github.com/gogo/protobuf/proto`	
+        - `go get github.com/gogo/protobuf/proto`
     - Install Python & dependencies
         - [if necessary] `brew install python3`
         - `python3 -m pip install -r pb-jelly-gen/requirements.txt`

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 bytes = "0.5.6"
-pb-jelly = "0.0.1"
+pb-jelly = "0.0.3"
 proto_box_it = { path = "gen/rust/proto/proto_box_it" }
 proto_custom_type = { path = "gen/rust/proto/proto_custom_type" }
 proto_linked_list = { path = "gen/rust/proto/proto_linked_list" }

--- a/examples/examples_gen/Cargo.toml
+++ b/examples/examples_gen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.1"  # If copying this example - use this
+#pb-jelly-gen = "0.0.3"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }

--- a/pb-jelly-gen/Cargo.toml
+++ b/pb-jelly-gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pb-jelly-gen"
 description = "A protobuf binding generation framework for the Rust language developed at Dropbox"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pb-jelly-gen/README.md
+++ b/pb-jelly-gen/README.md
@@ -2,7 +2,7 @@
 ###### It's working! It's working! - Anakin Skywalker
 [![Crates.io](https://img.shields.io/crates/v/pb-jelly-gen)](https://crates.io/crates/pb-jelly-gen) [![Documentation](https://docs.rs/pb-jelly-gen/badge.svg)](https://docs.rs/pb-jelly-gen) [![Crates.io](https://img.shields.io/crates/l/pb-jelly-gen)](LICENSE)
 
-This crate provides a tool to generate [`Rust`](https://www.rust-lang.org/) code from `proto2` or `proto3` files. 
+This crate provides a tool to generate [`Rust`](https://www.rust-lang.org/) code from `proto2` or `proto3` files.
 
 ### How To Use
 
@@ -21,7 +21,7 @@ Once you've completed the above steps, you should include this crate as a build-
 ##### `Cargo.toml`
 ```
 [build-dependencies]
-pb-jelly-gen = "0.0.1"
+pb-jelly-gen = "0.0.3"
 ```
 
 ##### `build.rs`

--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1616,7 +1616,7 @@ class Context(object):
             features = {u"serde": u' features = ["serde_derive"]'}
             versions = {
                 u"lazy_static": u' version = "1.4.0" ',
-                u"pb-jelly": u' version = "0.0.1" ',
+                u"pb-jelly": u' version = "0.0.3" ',
                 u"serde": u' version = "1.0.114" ',
                 u"bytes": u' version = "0.5.6" '
             }

--- a/pb-jelly/Cargo.toml
+++ b/pb-jelly/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pb-jelly"
 description = "A protobuf runtime for the Rust language developed at Dropbox"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pb-jelly/README.md
+++ b/pb-jelly/README.md
@@ -10,7 +10,7 @@ include this crate as a dependency in your `Cargo.toml`.
 ##### `Cargo.toml`
 ```
 [dependencies]
-pb-jelly = "0.0.1"
+pb-jelly = "0.0.3"
 ```
 
 Then in the general case, all you'll need to use in your code is the `Message` trait this crate defines, e.g.
@@ -18,5 +18,5 @@ Then in the general case, all you'll need to use in your code is the `Message` t
 use pb_jelly::Message;
 ```
 
-More complete examples can be found in the [`examples`](https://github.com/dropbox/pb-rs/tree/master/examples) crate, or 
+More complete examples can be found in the [`examples`](https://github.com/dropbox/pb-rs/tree/master/examples) crate, or
 the [`pb-test`](https://github.com/dropbox/pb-rs/tree/master/pb-test) crate itself.

--- a/pb-test/Cargo.toml
+++ b/pb-test/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.5.6"
-pb-jelly = "0.0.1"
+pb-jelly = "0.0.3"
 pretty_assertions = "0.6.1"
 proto_pbtest = { path = "gen/pb-jelly/proto_pbtest" }
 

--- a/pb-test/pb_test_gen/Cargo.toml
+++ b/pb-test/pb_test_gen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.1"  # If copying this example - use this
+#pb-jelly-gen = "0.0.3"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }
 
 # only used when benchmarking PROST!


### PR DESCRIPTION
When updating to 0.0.2 I forgot to update the codegen script to target 0.0.2 (whoops!). This PR updates the codegen script and all READMEs to target/reference 0.0.3