### PR TITLE
Allow proto files at root of proto path, without package

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1680,7 +1680,7 @@ def generate_single_crate(ctx: Context, file_prefix: Text, file_to_generate: Lis
 
         crate_name, mod_parts = ctx.crate_from_proto_filename(proto_file_name)
         parent_mods = mod_parts[:-1]
-        mod_name = mod_parts[-1]
+        mod_name = mod_parts[-1] if mod_parts else crate_name
 
         def add_mod(writer: CodeWriter) -> None:
             rs_file_name = (

--- a/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
@@ -1,0 +1,9 @@
+# @generated, do not edit
+[package]
+name = "proto_nopackage"
+version = "0.0.1"
+edition = "2018"
+
+[dependencies]
+lazy_static = { version = "1.4.0" }
+pb-jelly = { version = "0.0.4" }

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/lib.rs.expected
@@ -1,0 +1,16 @@
+// @generated, do not edit
+
+#![warn(rust_2018_idioms)]
+#![allow(clippy::float_cmp)]
+#![allow(irrefutable_let_patterns)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(irrefutable_let_patterns)]
+
+#[macro_use]
+extern crate lazy_static;
+
+pub mod proto_nopackage;

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
@@ -1,0 +1,71 @@
+// @generated, do not edit
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NoPackage {
+  pub field: ::std::string::String,
+}
+impl ::std::default::Default for NoPackage {
+  fn default() -> Self {
+    NoPackage {
+      field: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref NoPackage_default: NoPackage = NoPackage::default();
+}
+impl ::pb_jelly::Message for NoPackage {
+  fn compute_size(&self) -> usize  {
+    let mut size = 0;
+    let mut field_size = 0;
+    if self.field != <::std::string::String as ::std::default::Default>::default() {
+      let val = &self.field;
+      let l = ::pb_jelly::Message::compute_size(val);
+      field_size += ::pb_jelly::wire_format::serialized_length(1);
+      field_size += ::pb_jelly::varint::serialized_length(l as u64);
+      field_size += l;
+    }
+    size += field_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize  {
+    let mut size = 0;
+    if self.field != <::std::string::String as ::std::default::Default>::default() {
+      let val = &self.field;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if self.field != <::std::string::String as ::std::default::Default>::default() {
+      let val = &self.field;
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "NoPackage", 1)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: ::std::string::String = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.field = val;
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::MessageDescriptor for NoPackage {
+  const NAME: &'static str = "NoPackage";
+  const FULL_NAME: &'static str = "NoPackage";
+}
+

--- a/pb-test/proto/packages/nopackage.proto
+++ b/pb-test/proto/packages/nopackage.proto
@@ -1,0 +1,5 @@
+syntax="proto3";
+
+message NoPackage {
+    string field = 1;
+}

--- a/pb-test/src/verify_generated_files.rs
+++ b/pb-test/src/verify_generated_files.rs
@@ -23,7 +23,7 @@ fn verify_generated_files() {
 
     // Assert the correct number of pb-test generated files
     // Developers - please change this number if the change is intentional
-    assert_eq!(proto_files.len(), 9);
+    assert_eq!(proto_files.len(), 12);
 
     // Assert contents of the generated files
     for proto_file in proto_files {


### PR DESCRIPTION
This will give those proto files their own crate.
Added a test nopackage.proto at the root in pbtest to show this.
Fixes #78