### PR TITLE
    Fix rustfmt check in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ script:
     - cd ../..
 
     # Rustfmt
-    - for d in examples pb-jelly pb-jelly-gen pb-test; do cd $d ; cargo fmt -- --check ; cd .. ; done
+    - for d in examples pb-jelly pb-jelly-gen pb-test; do cd $d ; cargo fmt -- --check || exit ; cd .. ; done
 
     # unit tests
     - cd pb-jelly

--- a/pb-test/src/verify_generated_files.rs
+++ b/pb-test/src/verify_generated_files.rs
@@ -37,7 +37,10 @@ fn verify_generated_files() {
 
         let contents = fs::read_to_string(proto_file).unwrap();
         let expected_contents = fs::read_to_string(&expected).unwrap();
-        assert_eq!(contents.lines().collect::<Vec<_>>(), expected_contents.lines().collect::<Vec<_>>(),
-                   ".expected files don't match - Please run `cd pb-test ; cargo test` to generate");
+        assert_eq!(
+            contents.lines().collect::<Vec<_>>(),
+            expected_contents.lines().collect::<Vec<_>>(),
+            ".expected files don't match - Please run `cd pb-test ; cargo test` to generate"
+        );
     }
 }


### PR DESCRIPTION
Should works around the longstanding bug
https://github.com/travis-ci/travis-ci/issues/1066

I believe currently - our rustfmt check isn't taking effect
because the for loop marks as success even if a subcommand fails -
so hopefully this fixes that.