### PR TITLE
Add a test for non-optional Box'ed messages

### DIFF
--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -4213,6 +4213,146 @@ impl ::pb_jelly::MessageDescriptor for TestMessage3RepeatedErrIfDefaultEnum {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TestMessage3NonOptionalBoxedMessage {
+  pub msg: ::std::boxed::Box<TestMessage3NonOptionalBoxedMessage_InnerMessage>,
+}
+impl ::std::default::Default for TestMessage3NonOptionalBoxedMessage {
+  fn default() -> Self {
+    TestMessage3NonOptionalBoxedMessage {
+      msg: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref TestMessage3NonOptionalBoxedMessage_default: TestMessage3NonOptionalBoxedMessage = TestMessage3NonOptionalBoxedMessage::default();
+}
+impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage {
+  fn compute_size(&self) -> usize  {
+    let mut size = 0;
+    let mut msg_size = 0;
+     {
+      let val = &*self.msg;
+      let l = ::pb_jelly::Message::compute_size(val);
+      msg_size += ::pb_jelly::wire_format::serialized_length(1);
+      msg_size += ::pb_jelly::varint::serialized_length(l as u64);
+      msg_size += l;
+    }
+    size += msg_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize  {
+    let mut size = 0;
+     {
+      let val = &*self.msg;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+     {
+      let val = &*self.msg;
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3NonOptionalBoxedMessage", 1)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: TestMessage3NonOptionalBoxedMessage_InnerMessage = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.msg = Box::new(val);
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::MessageDescriptor for TestMessage3NonOptionalBoxedMessage {
+  const NAME: &'static str = "TestMessage3NonOptionalBoxedMessage";
+  const FULL_NAME: &'static str = "pbtest.TestMessage3NonOptionalBoxedMessage";
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TestMessage3NonOptionalBoxedMessage_InnerMessage {
+  pub name: ::std::string::String,
+}
+impl ::std::default::Default for TestMessage3NonOptionalBoxedMessage_InnerMessage {
+  fn default() -> Self {
+    TestMessage3NonOptionalBoxedMessage_InnerMessage {
+      name: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref TestMessage3NonOptionalBoxedMessage_InnerMessage_default: TestMessage3NonOptionalBoxedMessage_InnerMessage = TestMessage3NonOptionalBoxedMessage_InnerMessage::default();
+}
+impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage_InnerMessage {
+  fn compute_size(&self) -> usize  {
+    let mut size = 0;
+    let mut name_size = 0;
+    if self.name != <::std::string::String as ::std::default::Default>::default() {
+      let val = &self.name;
+      let l = ::pb_jelly::Message::compute_size(val);
+      name_size += ::pb_jelly::wire_format::serialized_length(1);
+      name_size += ::pb_jelly::varint::serialized_length(l as u64);
+      name_size += l;
+    }
+    size += name_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize  {
+    let mut size = 0;
+    if self.name != <::std::string::String as ::std::default::Default>::default() {
+      let val = &self.name;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if self.name != <::std::string::String as ::std::default::Default>::default() {
+      let val = &self.name;
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3NonOptionalBoxedMessage_InnerMessage", 1)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: ::std::string::String = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.name = val;
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::MessageDescriptor for TestMessage3NonOptionalBoxedMessage_InnerMessage {
+  const NAME: &'static str = "TestMessage3NonOptionalBoxedMessage_InnerMessage";
+  const FULL_NAME: &'static str = "pbtest.TestMessage3NonOptionalBoxedMessage_InnerMessage";
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TestPreserveUnrecognized1 {
   pub string1: ::std::string::String,
   pub _unrecognized: Vec<u8>,

--- a/pb-test/proto/packages/pbtest/pbtest3.proto
+++ b/pb-test/proto/packages/pbtest/pbtest3.proto
@@ -243,6 +243,14 @@ message TestMessage3RepeatedErrIfDefaultEnum {
     repeated TestMessage3ErrIfDefaultEnum.ErrIfDefaultEnum field = 1;
 }
 
+message TestMessage3NonOptionalBoxedMessage {
+    message InnerMessage {
+        string name = 1;
+    }
+
+    InnerMessage msg = 1 [(rust.box_it)=true, (gogoproto.nullable)=false];
+}
+
 message TestPreserveUnrecognized1 {
     option (rust.preserve_unrecognized) = true;
     string string1 = 1;


### PR DESCRIPTION
This PR adds a test to assert we generate the correct code for non-optional Box'ed messages, e.g.
```
message Foo {
    message Bar {}
    
    Bar bar = 1 [(rust.box_it)=true, (gogoproto.nullable)=false];
}
```
Note: Most of the time user's will run into this case unknowingly, because of the automatic boxing we do for recursive message definitions