### PR TITLE
Upgrade dependencies, bytes-1.0 and byteorder-1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Upcoming
-
+* When bumping to v0.0.6, also bump `bytes` to `1.0`
 
 # 0.0.5
 ### November 20, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Upcoming
-* When bumping to v0.0.6, also bump `bytes` to `1.0`
+* Bump `bytes` to `1.0`
 
 # 0.0.5
 ### November 20, 2020

--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1562,7 +1562,7 @@ class Context(object):
             versions = {
                 u"lazy_static": u' version = "1.4.0" ',
                 u"pb-jelly": u' version = "0.0.5" ',
-                u"serde": u' version = "1.0.114" ',
+                u"serde": u' version = "1.0" ',
                 u"bytes": u' version = "0.5.6" '
             }
 

--- a/pb-jelly/Cargo.toml
+++ b/pb-jelly/Cargo.toml
@@ -14,6 +14,6 @@ categories = ["encoding", "parsing", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-byteorder = "1.3.4"
-bytes = "0.5.6"
-serde = { version = "1.0.114", features = ["derive"] }
+byteorder = "1.4"
+bytes = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/pb-jelly/src/base_types.rs
+++ b/pb-jelly/src/base_types.rs
@@ -18,11 +18,8 @@ use byteorder::{
     WriteBytesExt,
 };
 use bytes::{
-    buf::{
-        ext::BufExt,
-        BufMut,
-    },
     Buf,
+    BufMut,
 };
 
 use super::{

--- a/pb-jelly/src/buffer.rs
+++ b/pb-jelly/src/buffer.rs
@@ -236,7 +236,7 @@ impl<'a> PbBufferWriter for Cursor<&'a mut Vec<u8>> {
         let mut reader = buf.clone().into_reader();
         while reader.has_remaining() {
             let n = {
-                let bytes = reader.bytes();
+                let bytes = reader.chunk();
                 self.write_all(bytes)?;
                 bytes.len()
             };
@@ -253,7 +253,7 @@ impl<'a> PbBufferWriter for Cursor<&'a mut [u8]> {
         let mut reader = buf.clone().into_reader();
         while reader.has_remaining() {
             let n = {
-                let bytes = reader.bytes();
+                let bytes = reader.chunk();
                 self.write_all(bytes)?;
                 bytes.len()
             };
@@ -287,7 +287,7 @@ impl<'a, W: Write + 'a> PbBufferWriter for CopyWriter<'a, W> {
         let mut reader = buf.clone().into_reader();
         while reader.has_remaining() {
             let n = {
-                let bytes = reader.bytes();
+                let bytes = reader.chunk();
                 self.write_all(bytes)?;
                 bytes.len()
             };

--- a/pb-jelly/src/lib.rs
+++ b/pb-jelly/src/lib.rs
@@ -20,7 +20,6 @@ use std::io::{
 
 use bytes::buf::{
     Buf,
-    BufExt,
     BufMut,
 };
 

--- a/pb-jelly/src/varint.rs
+++ b/pb-jelly/src/varint.rs
@@ -39,7 +39,7 @@ pub fn read<B: Buf>(buf: &mut B) -> io::Result<Option<u64>> {
 
     // Find offset of first byte with MSB not set
     let idx = match buf
-        .bytes()
+        .chunk()
         .iter()
         .enumerate()
         .find(|&(_, val)| *val < 0x80 as u8)
@@ -51,7 +51,7 @@ pub fn read<B: Buf>(buf: &mut B) -> io::Result<Option<u64>> {
     };
 
     let varint = {
-        let buf = &buf.bytes()[..=idx];
+        let buf = &buf.chunk()[..=idx];
 
         let mut r: u64 = 0;
         for byte in buf.iter().rev() {

--- a/pb-test/Cargo.toml
+++ b/pb-test/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "0.5.6"
+bytes = "1.0"
 pb-jelly = "0.0.5"
 pretty_assertions = "0.6.1"
 proto_pbtest = { path = "gen/pb-jelly/proto_pbtest" }

--- a/pb-test/Cargo.toml
+++ b/pb-test/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1.0"
+bytes = "0.5.6"
 pb-jelly = "0.0.5"
 pretty_assertions = "0.6.1"
 proto_pbtest = { path = "gen/pb-jelly/proto_pbtest" }


### PR DESCRIPTION
This diff updates a few dependencies:

[`bytes`](https://docs.rs/bytes/1.0.1/bytes/) recently went to 1.0, this PR updates the whole workspace to use `bytes 1.0`.
[`byteorder`](https://docs.rs/byteorder/1.4.2/byteorder/) was also out of date, this updates to `byteorder 1.4`
[`serde`](https://docs.rs/serde/1.0.123/serde/index.html) to specifically use `1.0` instead of providing an explicit build number, e.g. `1.0.xxx`.

This does not yet update the generated code to use `bytes 1.0` because that would break examples and tests. I left an item in `CHANGELOG.md` to bump bytes in generated code next time we bump the version number