### PR TITLE
Upgrade `pb-jelly-gen` to v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# Upcoming
+# 0.0.6
+### April 25, 2021
 * Bump `bytes` to `1.0`
+* Bump `byteorder` to `1.4`
 
 # 0.0.5
 ### November 20, 2020

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are only two crates you'll need if you want to use this with you project `
 Contains all of the important traits and structs that power our generated code, e.g. `Message` and `Lazy`. Include this as a `dependency`, e.g.
 ```
 [dependencies]
-pb-jelly = "0.0.5"
+pb-jelly = "0.0.6"
 ```
 
 ##### `pb-jelly-gen`
@@ -74,7 +74,7 @@ You'll need to add a generation crate (see `examples_gen` for an example)
 Include `pb-jelly-gen` as a dependency of your generation crate, and `cargo run` to invoke protoc for you.
 ```
 [dependencies]
-pb-jelly-gen = "0.0.5"
+pb-jelly-gen = "0.0.6"
 ```
 
 Eventually, we hope to eliminate the need for a generation crate, and simply have generation occur

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-bytes = "0.5.6"
-pb-jelly = "0.0.5"
+[dependencie
+bytes = "1.0"
+pb-jelly = "0.0.6"
 proto_box_it = { path = "gen/rust/proto/proto_box_it" }
 proto_custom_type = { path = "gen/rust/proto/proto_custom_type" }
 proto_linked_list = { path = "gen/rust/proto/proto_linked_list" }

--- a/examples/examples_gen/Cargo.toml
+++ b/examples/examples_gen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.5"  # If copying this example - use this
+#pb-jelly-gen = "0.0.6"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }

--- a/pb-jelly-gen/Cargo.toml
+++ b/pb-jelly-gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pb-jelly-gen"
 description = "A protobuf binding generation framework for the Rust language developed at Dropbox"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pb-jelly-gen/README.md
+++ b/pb-jelly-gen/README.md
@@ -21,7 +21,7 @@ Once you've completed the above steps, you should include this crate as a build-
 ##### `Cargo.toml`
 ```
 [build-dependencies]
-pb-jelly-gen = "0.0.5"
+pb-jelly-gen = "0.0.6"
 ```
 
 ##### `build.rs`

--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1561,9 +1561,9 @@ class Context(object):
             features = {u"serde": u' features = ["serde_derive"]'}
             versions = {
                 u"lazy_static": u' version = "1.4.0" ',
-                u"pb-jelly": u' version = "0.0.5" ',
+                u"pb-jelly": u' version = "0.0.6" ',
                 u"serde": u' version = "1.0" ',
-                u"bytes": u' version = "0.5.6" '
+                u"bytes": u' version = "1.0" '
             }
 
             deps_lines = []

--- a/pb-test/Cargo.toml
+++ b/pb-test/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "0.5.6"
-pb-jelly = "0.0.5"
+bytes = "1.0"
+pb-jelly = "0.0.6"
 pretty_assertions = "0.6.1"
 proto_pbtest = { path = "gen/pb-jelly/proto_pbtest" }
 walkdir = "2.3.1"

--- a/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.5" }
+pb-jelly = { version = "0.0.6" }

--- a/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.5" }
+pb-jelly = { version = "0.0.6" }

--- a/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
@@ -5,7 +5,7 @@ version = "0.0.1"
 edition = "2018"
 
 [dependencies]
-bytes = { version = "0.5.6" }
+bytes = { version = "1.0" }
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.5" }
+pb-jelly = { version = "0.0.6" }
 proto_google = {path = "../proto_google"}

--- a/pb-test/pb_test_gen/Cargo.toml
+++ b/pb-test/pb_test_gen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.5"  # If copying this example - use this
+#pb-jelly-gen = "0.0.6"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }
 
 # only used when benchmarking PROST!


### PR DESCRIPTION
This diff upgrades `pb-jelly-gen` to `v0.0.6`

* Codegen now targets `pb-jelly v0.0.6` and `bytes 1.0`
* Examples and Tests target `pb-jelly v0.0.6` and `bytes 1.0`
* Bumps `pb-jelly-gen` to `v0.0.6`