### PR TITLE
Add a [(rust.closed_enum)=true] option.

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -515,6 +515,12 @@ def enum_err_if_default_or_unknown(enum: EnumDescriptorProto) -> bool:
         and enum.options.Extensions[extensions_pb2.err_if_default_or_unknown]
     )
 
+def enum_closed(enum: EnumDescriptorProto) -> bool:
+    return (
+        enum.options.HasExtension(extensions_pb2.closed_enum)
+        and enum.options.Extensions[extensions_pb2.closed_enum]
+    )
+
 
 @contextmanager
 def block(ctx: 'CodeWriter', header: Text) -> Iterator[None]:
@@ -810,9 +816,12 @@ class CodeWriter(object):
         assert self.indentation == 0
         name = "_".join(path + [enum_type.name])
         if enum_err_if_default_or_unknown(enum_type):
+            assert not enum_closed(enum_type)
             self.gen_closed_enum(
                 name, [x for x in enumerate(enum_type.value) if x[1].number != 0], scl
             )
+        elif enum_closed(enum_type):
+            self.gen_closed_enum(name, list(enumerate(enum_type.value)), scl)
         else:
             self.gen_open_enum(name, list(enumerate(enum_type.value)), scl)
 

--- a/pb-jelly-gen/codegen/proto/rust/extensions_pb2.py
+++ b/pb-jelly-gen/codegen/proto/rust/extensions_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto2',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x15rust/extensions.proto\x12\x04rust\x1a google/protobuf/descriptor.proto:/\n\x06\x62ox_it\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\x08:4\n\x0bgrpc_slices\x12\x1d.google.protobuf.FieldOptions\x18\xd3\x86\x03 \x01(\x08:-\n\x04type\x12\x1d.google.protobuf.FieldOptions\x18\xd4\x86\x03 \x01(\t:2\n\tzero_copy\x12\x1d.google.protobuf.FieldOptions\x18\xd7\x86\x03 \x01(\x08:A\n\x19\x65rr_if_default_or_unknown\x12\x1c.google.protobuf.EnumOptions\x18\xd2\x86\x03 \x01(\x08:@\n\x15preserve_unrecognized\x12\x1f.google.protobuf.MessageOptions\x18\xd6\x86\x03 \x01(\x08:7\n\x08nullable\x12\x1d.google.protobuf.OneofOptions\x18\xd1\x86\x03 \x01(\x08:\x04true:;\n\x0cserde_derive\x12\x1c.google.protobuf.FileOptions\x18\xd5\x86\x03 \x01(\x08:\x05\x66\x61lse'
+  serialized_pb=b'\n\x15rust/extensions.proto\x12\x04rust\x1a google/protobuf/descriptor.proto:/\n\x06\x62ox_it\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\x08:4\n\x0bgrpc_slices\x12\x1d.google.protobuf.FieldOptions\x18\xd3\x86\x03 \x01(\x08:-\n\x04type\x12\x1d.google.protobuf.FieldOptions\x18\xd4\x86\x03 \x01(\t:2\n\tzero_copy\x12\x1d.google.protobuf.FieldOptions\x18\xd7\x86\x03 \x01(\x08:A\n\x19\x65rr_if_default_or_unknown\x12\x1c.google.protobuf.EnumOptions\x18\xd2\x86\x03 \x01(\x08:3\n\x0b\x63losed_enum\x12\x1c.google.protobuf.EnumOptions\x18\xd8\x86\x03 \x01(\x08:@\n\x15preserve_unrecognized\x12\x1f.google.protobuf.MessageOptions\x18\xd6\x86\x03 \x01(\x08:7\n\x08nullable\x12\x1d.google.protobuf.OneofOptions\x18\xd1\x86\x03 \x01(\x08:\x04true:;\n\x0cserde_derive\x12\x1c.google.protobuf.FileOptions\x18\xd5\x86\x03 \x01(\x08:\x05\x66\x61lse'
   ,
   dependencies=[google_dot_protobuf_dot_descriptor__pb2.DESCRIPTOR,])
 
@@ -65,9 +65,17 @@ err_if_default_or_unknown = _descriptor.FieldDescriptor(
   message_type=None, enum_type=None, containing_type=None,
   is_extension=True, extension_scope=None,
   serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key)
+CLOSED_ENUM_FIELD_NUMBER = 50008
+closed_enum = _descriptor.FieldDescriptor(
+  name='closed_enum', full_name='rust.closed_enum', index=5,
+  number=50008, type=8, cpp_type=7, label=1,
+  has_default_value=False, default_value=False,
+  message_type=None, enum_type=None, containing_type=None,
+  is_extension=True, extension_scope=None,
+  serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key)
 PRESERVE_UNRECOGNIZED_FIELD_NUMBER = 50006
 preserve_unrecognized = _descriptor.FieldDescriptor(
-  name='preserve_unrecognized', full_name='rust.preserve_unrecognized', index=5,
+  name='preserve_unrecognized', full_name='rust.preserve_unrecognized', index=6,
   number=50006, type=8, cpp_type=7, label=1,
   has_default_value=False, default_value=False,
   message_type=None, enum_type=None, containing_type=None,
@@ -75,7 +83,7 @@ preserve_unrecognized = _descriptor.FieldDescriptor(
   serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key)
 NULLABLE_FIELD_NUMBER = 50001
 nullable = _descriptor.FieldDescriptor(
-  name='nullable', full_name='rust.nullable', index=6,
+  name='nullable', full_name='rust.nullable', index=7,
   number=50001, type=8, cpp_type=7, label=1,
   has_default_value=True, default_value=True,
   message_type=None, enum_type=None, containing_type=None,
@@ -83,7 +91,7 @@ nullable = _descriptor.FieldDescriptor(
   serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key)
 SERDE_DERIVE_FIELD_NUMBER = 50005
 serde_derive = _descriptor.FieldDescriptor(
-  name='serde_derive', full_name='rust.serde_derive', index=7,
+  name='serde_derive', full_name='rust.serde_derive', index=8,
   number=50005, type=8, cpp_type=7, label=1,
   has_default_value=True, default_value=False,
   message_type=None, enum_type=None, containing_type=None,
@@ -95,6 +103,7 @@ DESCRIPTOR.extensions_by_name['grpc_slices'] = grpc_slices
 DESCRIPTOR.extensions_by_name['type'] = type
 DESCRIPTOR.extensions_by_name['zero_copy'] = zero_copy
 DESCRIPTOR.extensions_by_name['err_if_default_or_unknown'] = err_if_default_or_unknown
+DESCRIPTOR.extensions_by_name['closed_enum'] = closed_enum
 DESCRIPTOR.extensions_by_name['preserve_unrecognized'] = preserve_unrecognized
 DESCRIPTOR.extensions_by_name['nullable'] = nullable
 DESCRIPTOR.extensions_by_name['serde_derive'] = serde_derive
@@ -105,6 +114,7 @@ google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(grpc_slic
 google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(type)
 google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(zero_copy)
 google_dot_protobuf_dot_descriptor__pb2.EnumOptions.RegisterExtension(err_if_default_or_unknown)
+google_dot_protobuf_dot_descriptor__pb2.EnumOptions.RegisterExtension(closed_enum)
 google_dot_protobuf_dot_descriptor__pb2.MessageOptions.RegisterExtension(preserve_unrecognized)
 google_dot_protobuf_dot_descriptor__pb2.OneofOptions.RegisterExtension(nullable)
 google_dot_protobuf_dot_descriptor__pb2.FileOptions.RegisterExtension(serde_derive)

--- a/pb-jelly-gen/codegen/rust/extensions.proto
+++ b/pb-jelly-gen/codegen/rust/extensions.proto
@@ -36,6 +36,18 @@ extend google.protobuf.EnumOptions {
     // more desirable to just fail at parse time. If the client has updated *past* the server, it may
     // send a value that the server does not know how to handle. We *also* fail this at parse time.
     optional bool err_if_default_or_unknown = 50002;
+
+    // Setting this to true means that an enum's variants are considered exhaustive.
+    // A Rust `enum` will be generated, rather than a wrapper around `i32`. This
+    // makes matching against the enum simpler as there is no need to match
+    // unknown variants. Instead, deserialization will fail if an unknown
+    // variant is found over the wire. That makes adding or removing variants
+    // potentially unsafe when it comes to version skew.
+    //
+    // This option differs from `err_if_default_or_unknown` because default
+    // values are still allowed. The two options are incompatible, as
+    // `err_if_default_or_unknown` is strictly stronger.
+    optional bool closed_enum = 50008;
 }
 
 extend google.protobuf.MessageOptions {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -666,6 +666,96 @@ impl ::pb_jelly::ClosedProtoEnum for TestMessage3ErrIfDefaultEnumOneof_ErrIfDefa
   }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[repr(i32)]
+pub enum TestMessage3ClosedEnum_ClosedEnum {
+  DEFAULT = 0,
+  ONE = 1,
+}
+impl TestMessage3ClosedEnum_ClosedEnum {
+  pub const KNOWN_VARIANTS: [TestMessage3ClosedEnum_ClosedEnum; 2] = [TestMessage3ClosedEnum_ClosedEnum::DEFAULT, TestMessage3ClosedEnum_ClosedEnum::ONE];
+}
+impl ::std::default::Default for TestMessage3ClosedEnum_ClosedEnum {
+  fn default() -> Self {
+    TestMessage3ClosedEnum_ClosedEnum::DEFAULT
+  }
+}
+impl From<TestMessage3ClosedEnum_ClosedEnum> for i32 {
+  fn from(v: TestMessage3ClosedEnum_ClosedEnum) -> i32 {
+    match v {
+      TestMessage3ClosedEnum_ClosedEnum::DEFAULT => 0,
+      TestMessage3ClosedEnum_ClosedEnum::ONE => 1,
+    }
+  }
+}
+impl ::std::convert::TryFrom<i32> for TestMessage3ClosedEnum_ClosedEnum {
+  type Error = i32;
+  fn try_from(v: i32) -> ::std::result::Result<Self, i32> {
+    match v {
+      0 => Ok(TestMessage3ClosedEnum_ClosedEnum::DEFAULT),
+      1 => Ok(TestMessage3ClosedEnum_ClosedEnum::ONE),
+      _ => Err(v),
+    }
+  }
+}
+impl ::pb_jelly::ProtoEnum for TestMessage3ClosedEnum_ClosedEnum {
+}
+impl ::pb_jelly::ClosedProtoEnum for TestMessage3ClosedEnum_ClosedEnum {
+  fn name(self) -> &'static str {
+    match self {
+      TestMessage3ClosedEnum_ClosedEnum::DEFAULT => "DEFAULT",
+      TestMessage3ClosedEnum_ClosedEnum::ONE => "ONE",
+    }
+  }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[repr(i32)]
+pub enum TestMessage3ClosedEnum2_ClosedEnum {
+  DEFAULT = 0,
+  ONE = 1,
+  TWO = 2,
+}
+impl TestMessage3ClosedEnum2_ClosedEnum {
+  pub const KNOWN_VARIANTS: [TestMessage3ClosedEnum2_ClosedEnum; 3] = [TestMessage3ClosedEnum2_ClosedEnum::DEFAULT, TestMessage3ClosedEnum2_ClosedEnum::ONE, TestMessage3ClosedEnum2_ClosedEnum::TWO];
+}
+impl ::std::default::Default for TestMessage3ClosedEnum2_ClosedEnum {
+  fn default() -> Self {
+    TestMessage3ClosedEnum2_ClosedEnum::DEFAULT
+  }
+}
+impl From<TestMessage3ClosedEnum2_ClosedEnum> for i32 {
+  fn from(v: TestMessage3ClosedEnum2_ClosedEnum) -> i32 {
+    match v {
+      TestMessage3ClosedEnum2_ClosedEnum::DEFAULT => 0,
+      TestMessage3ClosedEnum2_ClosedEnum::ONE => 1,
+      TestMessage3ClosedEnum2_ClosedEnum::TWO => 2,
+    }
+  }
+}
+impl ::std::convert::TryFrom<i32> for TestMessage3ClosedEnum2_ClosedEnum {
+  type Error = i32;
+  fn try_from(v: i32) -> ::std::result::Result<Self, i32> {
+    match v {
+      0 => Ok(TestMessage3ClosedEnum2_ClosedEnum::DEFAULT),
+      1 => Ok(TestMessage3ClosedEnum2_ClosedEnum::ONE),
+      2 => Ok(TestMessage3ClosedEnum2_ClosedEnum::TWO),
+      _ => Err(v),
+    }
+  }
+}
+impl ::pb_jelly::ProtoEnum for TestMessage3ClosedEnum2_ClosedEnum {
+}
+impl ::pb_jelly::ClosedProtoEnum for TestMessage3ClosedEnum2_ClosedEnum {
+  fn name(self) -> &'static str {
+    match self {
+      TestMessage3ClosedEnum2_ClosedEnum::DEFAULT => "DEFAULT",
+      TestMessage3ClosedEnum2_ClosedEnum::ONE => "ONE",
+      TestMessage3ClosedEnum2_ClosedEnum::TWO => "TWO",
+    }
+  }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ForeignMessage3 {
   pub c: i32,
@@ -4210,6 +4300,136 @@ impl ::pb_jelly::Message for TestMessage3RepeatedErrIfDefaultEnum {
 impl ::pb_jelly::MessageDescriptor for TestMessage3RepeatedErrIfDefaultEnum {
   const NAME: &'static str = "TestMessage3RepeatedErrIfDefaultEnum";
   const FULL_NAME: &'static str = "pbtest.TestMessage3RepeatedErrIfDefaultEnum";
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TestMessage3ClosedEnum {
+  pub value: TestMessage3ClosedEnum_ClosedEnum,
+}
+impl ::std::default::Default for TestMessage3ClosedEnum {
+  fn default() -> Self {
+    TestMessage3ClosedEnum {
+      value: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref TestMessage3ClosedEnum_default: TestMessage3ClosedEnum = TestMessage3ClosedEnum::default();
+}
+impl ::pb_jelly::Message for TestMessage3ClosedEnum {
+  fn compute_size(&self) -> usize  {
+    let mut size = 0;
+    let mut value_size = 0;
+    if self.value != <TestMessage3ClosedEnum_ClosedEnum as ::std::default::Default>::default() {
+      let val = &self.value;
+      let l = ::pb_jelly::Message::compute_size(val);
+      value_size += ::pb_jelly::wire_format::serialized_length(1);
+      value_size += l;
+    }
+    size += value_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize  {
+    let mut size = 0;
+    if self.value != <TestMessage3ClosedEnum_ClosedEnum as ::std::default::Default>::default() {
+      let val = &self.value;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if self.value != <TestMessage3ClosedEnum_ClosedEnum as ::std::default::Default>::default() {
+      let val = &self.value;
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ClosedEnum", 1)?;
+          let mut val: TestMessage3ClosedEnum_ClosedEnum = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          self.value = val;
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::MessageDescriptor for TestMessage3ClosedEnum {
+  const NAME: &'static str = "TestMessage3ClosedEnum";
+  const FULL_NAME: &'static str = "pbtest.TestMessage3ClosedEnum";
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TestMessage3ClosedEnum2 {
+  pub value: TestMessage3ClosedEnum2_ClosedEnum,
+}
+impl ::std::default::Default for TestMessage3ClosedEnum2 {
+  fn default() -> Self {
+    TestMessage3ClosedEnum2 {
+      value: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref TestMessage3ClosedEnum2_default: TestMessage3ClosedEnum2 = TestMessage3ClosedEnum2::default();
+}
+impl ::pb_jelly::Message for TestMessage3ClosedEnum2 {
+  fn compute_size(&self) -> usize  {
+    let mut size = 0;
+    let mut value_size = 0;
+    if self.value != <TestMessage3ClosedEnum2_ClosedEnum as ::std::default::Default>::default() {
+      let val = &self.value;
+      let l = ::pb_jelly::Message::compute_size(val);
+      value_size += ::pb_jelly::wire_format::serialized_length(1);
+      value_size += l;
+    }
+    size += value_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize  {
+    let mut size = 0;
+    if self.value != <TestMessage3ClosedEnum2_ClosedEnum as ::std::default::Default>::default() {
+      let val = &self.value;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if self.value != <TestMessage3ClosedEnum2_ClosedEnum as ::std::default::Default>::default() {
+      let val = &self.value;
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ClosedEnum2", 1)?;
+          let mut val: TestMessage3ClosedEnum2_ClosedEnum = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          self.value = val;
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::MessageDescriptor for TestMessage3ClosedEnum2 {
+  const NAME: &'static str = "TestMessage3ClosedEnum2";
+  const FULL_NAME: &'static str = "pbtest.TestMessage3ClosedEnum2";
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/pb-test/proto/includes/rust/extensions.proto
+++ b/pb-test/proto/includes/rust/extensions.proto
@@ -36,6 +36,18 @@ extend google.protobuf.EnumOptions {
     // more desirable to just fail at parse time. If the client has updated *past* the server, it may
     // send a value that the server does not know how to handle. We *also* fail this at parse time.
     optional bool err_if_default_or_unknown = 50002;
+
+    // Setting this to true means that an enum's variants are considered exhaustive.
+    // A Rust `enum` will be generated, rather than a wrapper around `i32`. This
+    // makes matching against the enum simpler as there is no need to match
+    // unknown variants. Instead, deserialization will fail if an unknown
+    // variant is found over the wire. That makes adding or removing variants
+    // potentially unsafe when it comes to version skew.
+    //
+    // This option differs from `err_if_default_or_unknown` because default
+    // values are still allowed. The two options are incompatible, as
+    // `err_if_default_or_unknown` is strictly stronger.
+    optional bool closed_enum = 50008;
 }
 
 extend google.protobuf.MessageOptions {

--- a/pb-test/proto/packages/pbtest/pbtest3.proto
+++ b/pb-test/proto/packages/pbtest/pbtest3.proto
@@ -243,6 +243,27 @@ message TestMessage3RepeatedErrIfDefaultEnum {
     repeated TestMessage3ErrIfDefaultEnum.ErrIfDefaultEnum field = 1;
 }
 
+message TestMessage3ClosedEnum {
+    enum ClosedEnum {
+        option (rust.closed_enum) = true;
+
+        DEFAULT = 0;
+        ONE = 1;
+    }
+    ClosedEnum value = 1;
+}
+
+message TestMessage3ClosedEnum2 {
+    enum ClosedEnum {
+        option (rust.closed_enum) = true;
+
+        DEFAULT = 0;
+        ONE = 1;
+        TWO = 2;
+    }
+    ClosedEnum value = 1;
+}
+
 message TestMessage3NonOptionalBoxedMessage {
     message InnerMessage {
         string name = 1;

--- a/pb-test/src/pbtest.rs
+++ b/pb-test/src/pbtest.rs
@@ -538,6 +538,48 @@ fn repeated_err_if_default_non_default_succeeds() {
     succeeds(&buf[..], expected);
 }
 
+#[test]
+fn closed_enum() {
+    succeeds(
+        &[],
+        TestMessage3ClosedEnum {
+            value: TestMessage3ClosedEnum_ClosedEnum::DEFAULT,
+        },
+    );
+    succeeds(
+        &TestMessage3ClosedEnum2 {
+            value: TestMessage3ClosedEnum2_ClosedEnum::DEFAULT,
+        }
+        .serialize_to_vec(),
+        TestMessage3ClosedEnum {
+            value: TestMessage3ClosedEnum_ClosedEnum::DEFAULT,
+        },
+    );
+    succeeds(
+        &TestMessage3ClosedEnum2 {
+            value: TestMessage3ClosedEnum2_ClosedEnum::ONE,
+        }
+        .serialize_to_vec(),
+        TestMessage3ClosedEnum {
+            value: TestMessage3ClosedEnum_ClosedEnum::ONE,
+        },
+    );
+    TestMessage3ClosedEnum::deserialize_from_slice(
+        &TestMessage3ClosedEnum2 {
+            value: TestMessage3ClosedEnum2_ClosedEnum::TWO,
+        }
+        .serialize_to_vec(),
+    )
+    .expect_err("should fail");
+
+    // Check that the codegen is actually generating a closed enum
+    match TestMessage3ClosedEnum2_ClosedEnum::DEFAULT {
+        TestMessage3ClosedEnum2_ClosedEnum::DEFAULT
+        | TestMessage3ClosedEnum2_ClosedEnum::ONE
+        | TestMessage3ClosedEnum2_ClosedEnum::TWO => (),
+    }
+}
+
 //TODO: Add blob crate so we can bring this test back.
 /*
 #[test]


### PR DESCRIPTION
This option replaces the normally generated open enum with its `_Closed`
variant. That means the enum is required to be a known variant at
deserialization time. This makes using enums more ergonomic for
situations where version skew is not relevant, or is dealt with some
other way (e.g. migrations)