### PR TITLE
Fix the Cargo.toml in the examples crate

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencie
+[dependencies]
 bytes = "1.0"
 pb-jelly = "0.0.6"
 proto_box_it = { path = "gen/rust/proto/proto_box_it" }


### PR DESCRIPTION
I accidentally broke the Cargo.toml in the examples crate, this fixes it