### PR TITLE
Prep `pb-jelly-gen` for v0.0.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You'll need to add a generation crate (see `examples_gen` for an example)
 Include `pb-jelly-gen` as a dependency of your generation crate, and `cargo run` to invoke protoc for you.
 ```
 [dependencies]
-pb-jelly-gen = "0.0.6"
+pb-jelly-gen = "0.0.7"
 ```
 
 Eventually, we hope to eliminate the need for a generation crate, and simply have generation occur

--- a/pb-jelly-gen/Cargo.toml
+++ b/pb-jelly-gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pb-jelly-gen"
 description = "A protobuf binding generation framework for the Rust language developed at Dropbox"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pb-jelly-gen/README.md
+++ b/pb-jelly-gen/README.md
@@ -21,7 +21,7 @@ Once you've completed the above steps, you should include this crate as a build-
 ##### `Cargo.toml`
 ```
 [build-dependencies]
-pb-jelly-gen = "0.0.6"
+pb-jelly-gen = "0.0.7"
 ```
 
 ##### `build.rs`

--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1570,7 +1570,7 @@ class Context(object):
             features = {u"serde": u' features = ["serde_derive"]'}
             versions = {
                 u"lazy_static": u' version = "1.4.0" ',
-                u"pb-jelly": u' version = "0.0.6" ',
+                u"pb-jelly": u' version = "0.0.7" ',
                 u"serde": u' version = "1.0" ',
                 u"bytes": u' version = "1.0" '
             }


### PR DESCRIPTION
Prep `pb-jelly-gen` for a `v0.0.7` release which includes the new `rust.closed_enum` proto extension