### PR TITLE
Update tests and examples to use v0.0.7

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 bytes = "1.0"
-pb-jelly = "0.0.6"
+pb-jelly = "0.0.7"
 proto_box_it = { path = "gen/rust/proto/proto_box_it" }
 proto_custom_type = { path = "gen/rust/proto/proto_custom_type" }
 proto_linked_list = { path = "gen/rust/proto/proto_linked_list" }

--- a/examples/examples_gen/Cargo.toml
+++ b/examples/examples_gen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.6"  # If copying this example - use this
+#pb-jelly-gen = "0.0.7"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }

--- a/pb-test/Cargo.toml
+++ b/pb-test/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "1.0"
-pb-jelly = "0.0.6"
+pb-jelly = "0.0.7"
 pretty_assertions = "0.6.1"
 proto_pbtest = { path = "gen/pb-jelly/proto_pbtest" }
 walkdir = "2.3.1"

--- a/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.6" }
+pb-jelly = { version = "0.0.7" }

--- a/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.6" }
+pb-jelly = { version = "0.0.7" }

--- a/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 bytes = { version = "1.0" }
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.6" }
+pb-jelly = { version = "0.0.7" }
 proto_google = {path = "../proto_google"}

--- a/pb-test/pb_test_gen/Cargo.toml
+++ b/pb-test/pb_test_gen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.6"  # If copying this example - use this
+#pb-jelly-gen = "0.0.7"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }
 
 # only used when benchmarking PROST!


### PR DESCRIPTION
Like the title says, update tests and examples to use `v0.0.7`