### PR TITLE
Use setup.cfg to install codegen to protoc-gen-rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Use github CI for tests, rustfmt, black, mypy --strict
 * Support windows for codegen
 * Rename master branch to main
+* Use a setup.cfg to install protoc-gen-rust to avoid need for --plugin flag. Simplifies manual usage process, especially on windows (no need for codegen.bat)
+* Remove need for requirements.txt - by using setup.cfg `install_requires`
 
 # 0.0.7
 ### May 5, 2021

--- a/README.md
+++ b/README.md
@@ -86,10 +86,20 @@ Note that you can always invoke protoc on your own (for example if you are alrea
 with `--rust_out=codegen.py` as a plugin for rust.
 
 ### Generating Rust Code
-In order to generate Rust code from your proto definitions you'll need three things
-1. `protoc` - The protobuf compiler, this can be built from source [`protobuf`](https://github.com/protocolbuffers/protobuf) or installed via `brew install protobuf`.
-2. `python` - The codegen plugin used with `protoc` is written in Python (compatible with both py2 and py3). Before running it, you'll need to install some packages, via `python -m pip install -r pb-jelly-gen/requirements.txt`
-3. `pb-jelly-gen` [optional - you may always invoke protoc on your own]
+1. Install `protoc` - The protobuf compiler, this can be downloaded or built from source [`protobuf`](https://github.com/protocolbuffers/protobuf) or installed (mac) via `brew install protobuf`.
+2. `python3` - The codegen plugin used with `protoc` is written in Python3.
+
+#### To generate with pb-jelly-gen
+3. Create an inner (build-step) crate which depends on pb-jelly-gen. [Example](https://github.com/dropbox/pb-jelly/tree/master/examples/examples_gen)
+4. `cargo run` in the directory of the inner generation crate
+
+#### To generate manually with protoc
+3. Create venv [optional] `python3 -m venv .pb_jelly_venv ; source .pb_jelly_venv/bin/activate`
+4. [Recommended] `python3 -m pip install protobuf==[same_version_as_your protoc]`
+5. Install `python3 -m pip install -e pb-jelly-gen/codegen`  (installs protoc-gen-rust into the venv)
+6. `protoc --rust_out=generated/ input.proto`
+
+## Example
 
 Take a look at the [`examples`](https://github.com/dropbox/pb-jelly/tree/main/examples/src) crate to see how we leverage `pb-jelly-gen` and `build.rs` to get started using protobufs in Rust!
 
@@ -149,9 +159,8 @@ Service Generation
    package manager. Use the appropriate package manager for your system.
     - protoc - part of Google's [protobuf tools](https://github.com/protocolbuffers/protobuf/)
         - `brew install protobuf`
-    - Install Python & dependencies
+    - Install Python
         - [if necessary] `brew install python3`
-        - `python3 -m pip install -r pb-jelly-gen/requirements.txt`
 3. **pb-jelly** currently uses an experimental test framework that requires a nightly build of rust.
 	-  `rustup default nightly`
 4. `cd pb-test`

--- a/pb-jelly-gen/README.md
+++ b/pb-jelly-gen/README.md
@@ -8,13 +8,10 @@ This crate provides a tool to generate [`Rust`](https://www.rust-lang.org/) code
 
 ##### `python` + `protoc`
 The core of this crate is a python script `codegen.py` that is provided to the protobuf compiler, `protoc` as a plugin.
-There are a few python depdendencies which can be installed by running one of two commands:
-1. Running `pip install six protobuf typing` or...
-2. Running `pip install -r requirements.txt` from the root of this crate, if you have it cloned.
 
-You'll also need the protobuf compiler which you can get by:
+You'll need the protobuf compiler which you can get by:
 1. Running `brew install protobuf` or...
-2. Build from source [`protobuf`](https://github.com/protocolbuffers/protobuf)
+2. Download or build from source [`protobuf`](https://github.com/protocolbuffers/protobuf)
 
 Once you've completed the above steps, you should include this crate as a build-dependency in your `Cargo.toml` and then call the API of this crate from a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) files in the root of your repo.
 

--- a/pb-jelly-gen/codegen/codegen.bat
+++ b/pb-jelly-gen/codegen/codegen.bat
@@ -1,2 +1,0 @@
-@echo off
-python -u %0\..\codegen.py

--- a/pb-jelly-gen/codegen/pyproject.toml
+++ b/pb-jelly-gen/codegen/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/pb-jelly-gen/codegen/setup.cfg
+++ b/pb-jelly-gen/codegen/setup.cfg
@@ -1,0 +1,13 @@
+[metadata]
+name = pb-jelly codegen
+version = 0.0.1
+description = Generate rust bindings from protobuf specs
+keywords = rust proto dropbox
+license = Apache License 2.0
+url = https://github.com/dropbox/pb-jelly
+
+[options.entry_points]
+console_scripts =
+    protoc-gen-rust = codegen:main
+install_requires =
+    protobuf>=3.13.0

--- a/pb-jelly-gen/requirements.txt
+++ b/pb-jelly-gen/requirements.txt
@@ -1,2 +1,0 @@
-protobuf==3.13.0
-typing==3.7.4.3


### PR DESCRIPTION
Installs to protoc-gen-rust
Updated README instructions for manual protoc usage
Should obviate need for codegen.bat on windows by leveraging entrypoints.