### PR TITLE
[pb-jelly-gen] Simplify as_ref().map with as_deref

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -423,7 +423,7 @@ class RustType(object):
             assert not (
                 self.is_blob() or self.is_grpc_slices() or self.is_lazy_bytes()
             ), "Can't generate get method for lazy field"
-            return "&[u8]", "self.%s.as_ref().map(|v| &**v).unwrap_or(&[])" % name
+            return "&[u8]", "self.%s.as_deref().unwrap_or(&[])" % name
         elif self.field.type == FieldDescriptorProto.TYPE_ENUM:
             return self.rust_type(), "self.%s.unwrap_or_default()" % name
         elif self.field.type == FieldDescriptorProto.TYPE_MESSAGE:

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
@@ -94,7 +94,7 @@ impl VecData {
     self.data.take().unwrap_or_default()
   }
   pub fn get_data(&self) -> &[u8] {
-    self.data.as_ref().map(|v| &**v).unwrap_or(&[])
+    self.data.as_deref().unwrap_or(&[])
   }
 }
 impl ::std::default::Default for VecData {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -1375,7 +1375,7 @@ impl Version2 {
     self.optional_bytes.take().unwrap_or_default()
   }
   pub fn get_optional_bytes(&self) -> &[u8] {
-    self.optional_bytes.as_ref().map(|v| &**v).unwrap_or(&[])
+    self.optional_bytes.as_deref().unwrap_or(&[])
   }
   pub fn has_optional_float(&self) -> bool {
     self.optional_float.is_some()
@@ -2007,7 +2007,7 @@ impl TestMessage {
     self.optional_bytes.take().unwrap_or_default()
   }
   pub fn get_optional_bytes(&self) -> &[u8] {
-    self.optional_bytes.as_ref().map(|v| &**v).unwrap_or(&[])
+    self.optional_bytes.as_deref().unwrap_or(&[])
   }
   pub fn has_optional_float(&self) -> bool {
     self.optional_float.is_some()


### PR DESCRIPTION
From this clippy:

>  warning: called `.as_ref().map(|v| &**v)` on an Option value. This
> can be done more directly by calling `self.string_value.as_deref()`
> instead
>
>  |     self.string_value.as_ref().map(|v| &**v).unwrap_or(&[])
>  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using
> as_deref instead: `self.string_value.as_deref()`

I did some experiments locally and it seems OK. Tests also work.