### PR TITLE
[pb-jelly-gen] Suppress inception lint

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1745,6 +1745,7 @@ RS_HEADER = "// @" + "generated, do not edit\n"
 LIB_RS_HEADER = """
 #![warn(rust_2018_idioms)]
 #![allow(clippy::float_cmp)]
+#![allow(clippy::module_inception)]
 #![allow(irrefutable_let_patterns)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/pb-test/gen/pb-jelly/proto_google/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_google/src/lib.rs.expected
@@ -2,6 +2,7 @@
 
 #![warn(rust_2018_idioms)]
 #![allow(clippy::float_cmp)]
+#![allow(clippy::module_inception)]
 #![allow(irrefutable_let_patterns)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/lib.rs.expected
@@ -2,6 +2,7 @@
 
 #![warn(rust_2018_idioms)]
 #![allow(clippy::float_cmp)]
+#![allow(clippy::module_inception)]
 #![allow(irrefutable_let_patterns)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
@@ -2,6 +2,7 @@
 
 #![warn(rust_2018_idioms)]
 #![allow(clippy::float_cmp)]
+#![allow(clippy::module_inception)]
 #![allow(irrefutable_let_patterns)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Clippy says:
> module has the same name as it's containing module

I think changing this would be a breaking change, because imports would
have to change. There's also no obvious better name to use that would
work in the general case.

So I silenced the lint.