### PR TITLE
Bump pb-jelly to v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+
+
+# 0.0.8
+### October 25, 2021
 * Move `(gogoproto.nullable)` option to `(rust.nullable_field)`, removing the dependency on gogoproto
 * Support running with any version of protoc (by dynamically generating `extensions_pb2.py` in a venv)
 * Use github CI for tests, rustfmt, black, mypy --strict

--- a/pb-jelly/Cargo.toml
+++ b/pb-jelly/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pb-jelly"
 description = "A protobuf runtime for the Rust language developed at Dropbox"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pb-jelly/README.md
+++ b/pb-jelly/README.md
@@ -10,7 +10,7 @@ include this crate as a dependency in your `Cargo.toml`.
 ##### `Cargo.toml`
 ```
 [dependencies]
-pb-jelly = "0.0.7"
+pb-jelly = "0.0.8"
 ```
 
 Then in the general case, all you'll need to use in your code is the `Message` trait this crate defines, e.g.


### PR DESCRIPTION
This diff just bumps the version of `pb-jelly` to v0.0.8