### PR TITLE
[pb-jelly-gen] Simplify String->str with as_deref

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -417,7 +417,7 @@ class RustType(object):
         elif self.field.type == FieldDescriptorProto.TYPE_STRING:
             return (
                 "&str",
-                'self.%s.as_ref().map(|s| s.as_str()).unwrap_or("")' % name,
+                'self.%s.as_deref().unwrap_or("")' % name,
             )
         elif self.field.type == FieldDescriptorProto.TYPE_BYTES:
             assert not (

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
@@ -175,7 +175,7 @@ impl StringMessage {
     self.data.take().unwrap_or_default()
   }
   pub fn get_data(&self) -> &str {
-    self.data.as_ref().map(|s| s.as_str()).unwrap_or("")
+    self.data.as_deref().unwrap_or("")
   }
 }
 impl ::std::default::Default for StringMessage {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -1167,7 +1167,7 @@ impl Version1 {
     self.required_string.take().unwrap_or_default()
   }
   pub fn get_required_string(&self) -> &str {
-    self.required_string.as_ref().map(|s| s.as_str()).unwrap_or("")
+    self.required_string.as_deref().unwrap_or("")
   }
 }
 impl ::std::default::Default for Version1 {
@@ -1261,7 +1261,7 @@ impl Version2 {
     self.required_string.take().unwrap_or_default()
   }
   pub fn get_required_string(&self) -> &str {
-    self.required_string.as_ref().map(|s| s.as_str()).unwrap_or("")
+    self.required_string.as_deref().unwrap_or("")
   }
   pub fn has_optional_int32(&self) -> bool {
     self.optional_int32.is_some()
@@ -1363,7 +1363,7 @@ impl Version2 {
     self.optional_string.take().unwrap_or_default()
   }
   pub fn get_optional_string(&self) -> &str {
-    self.optional_string.as_ref().map(|s| s.as_str()).unwrap_or("")
+    self.optional_string.as_deref().unwrap_or("")
   }
   pub fn has_optional_bytes(&self) -> bool {
     self.optional_bytes.is_some()
@@ -1995,7 +1995,7 @@ impl TestMessage {
     self.optional_string.take().unwrap_or_default()
   }
   pub fn get_optional_string(&self) -> &str {
-    self.optional_string.as_ref().map(|s| s.as_str()).unwrap_or("")
+    self.optional_string.as_deref().unwrap_or("")
   }
   pub fn has_optional_bytes(&self) -> bool {
     self.optional_bytes.is_some()


### PR DESCRIPTION
Fixes clippy:
> warning: called `.as_ref().map(|s| s.as_str())` on an Option value.
> This can be done more directly by calling `string.as_deref()` instead