### PR TITLE
Rework how zerocopy works, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
-* Everything has been released!
+* Simplify the zerocopy implementation. (#127)
+  * `PbBuffer` has been reworked to untie it from `PbBufferReader`.
+    * `copy_from_reader` replaces `from_reader` and allows a `PbBuffer` to be constructed, by copying, from any `Buf`. Implementations can still opt out by returning `Err`.
+    * `copy_to_writer` replaces `into_reader`. Callers that were using `into_reader` to call `Message::deserialize` should instead construct their desired `PbBufferReader` directly (e.g. `Cursor<Bytes>`).
+  * `PbBufferReader::as_buffer` is renamed to `read_buffer`, and provided implementations fall back to copying `Lazy` fields by default (instead of returning an error).
 
 # 0.0.9
 ### November 2, 2021

--- a/pb-jelly/src/lib.rs
+++ b/pb-jelly/src/lib.rs
@@ -28,7 +28,7 @@ pub mod wire_format;
 
 mod buffer;
 pub use crate::buffer::{
-    cast_buffer,
+    type_is,
     CopyWriter,
     Lazy,
     PbBuffer,

--- a/pb-test/src/bench.rs
+++ b/pb-test/src/bench.rs
@@ -4,13 +4,13 @@ mod benches {
     use pb_jelly::{
         Lazy,
         Message,
-        PbBuffer,
     };
     use proto_pbtest::bench::{
         BytesData,
         StringMessage,
         VecData,
     };
+    use std::io::Cursor;
     use test::Bencher;
 
     #[bench]
@@ -31,13 +31,11 @@ mod benches {
         let bytes_buf = Bytes::from(ser_bytes);
 
         b.iter(|| {
-            // Convert our bytes::Bytes into a pb::PbBufferReader
-            let mut bytes_reader = bytes_buf.clone().into_reader();
-
             // Deserialize our proto
             let mut de_proto = BytesData::default();
-            de_proto.deserialize(&mut bytes_reader).unwrap();
+            de_proto.deserialize(&mut Cursor::new(bytes_buf.clone())).unwrap();
             assert!(de_proto.has_data());
+            de_proto
         });
     }
 
@@ -59,13 +57,11 @@ mod benches {
         let bytes_buf = Bytes::from(ser_bytes);
 
         b.iter(|| {
-            // Convert our bytes::Bytes into a pb::PbBufferReader
-            let mut bytes_reader = bytes_buf.clone().into_reader();
-
             // Deserialize our proto
             let mut de_proto = VecData::default();
-            de_proto.deserialize(&mut bytes_reader).unwrap();
+            de_proto.deserialize(&mut Cursor::new(bytes_buf.clone())).unwrap();
             assert!(de_proto.has_data());
+            de_proto
         });
     }
 
@@ -81,13 +77,11 @@ mod benches {
         let bytes_buf = Bytes::from(ser_bytes);
 
         b.iter(|| {
-            // Convert our bytes::Bytes into a pb::PbBufferReader
-            let mut bytes_reader = bytes_buf.clone().into_reader();
-
             // Deserialize our proto
             let mut de_proto = StringMessage::default();
-            de_proto.deserialize(&mut bytes_reader).unwrap();
+            de_proto.deserialize(&mut Cursor::new(bytes_buf.clone())).unwrap();
             assert!(de_proto.has_data());
+            de_proto
         });
     }
 }


### PR DESCRIPTION
This PR attempts to simplify the `Lazy` system again by removing more indirection.
`PbBuffer` is now a more self-contained trait, without reference to `PbBufferReader`/`Writer`, and merely acts as a container. Instead, type-dispatch logic is pushed solely into `PbBufferReader`/`PbBufferWriter`.