### PR TITLE
Add a [patch] for pb-jelly to pb-test

### DIFF
--- a/pb-test/Cargo.toml
+++ b/pb-test/Cargo.toml
@@ -21,3 +21,7 @@ protobuf = { version = "2.17", features = ["with-bytes"], optional = true }
 [features]
 bench_prost = ["prost"]
 bench_rust_protobuf = ["protobuf"]
+
+# Override pb-jelly dependency for generated crates as well
+[patch.crates-io]
+pb-jelly = { path = "../pb-jelly" }


### PR DESCRIPTION
This makes it possible to change pb-jelly and its dependents (e.g. pb-jelly-gen) simultaneously.