### PR TITLE
Add a top-level package section in Spec.toml

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1719,6 +1719,7 @@ rust_doc(
 SPEC_TOML_TEMPLATE = (
     """# @"""
     + """generated, do not edit
+[package]
 name = "{crate}"
 edition = "2018"
 


### PR DESCRIPTION
Our `Spec.toml` format now looks more like `Cargo.toml` and the top level attributes are under a `package` section.