### PR TITLE
Bump pb-jelly-gen to v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+... everything has been released!
+
+# 0.0.10
+### November 30, 2021
 * Simplify the zerocopy implementation. (#127)
   * `PbBuffer` has been reworked to untie it from `PbBufferReader`.
     * `copy_from_reader` replaces `from_reader` and allows a `PbBuffer` to be constructed, by copying, from any `Buf`. Implementations can still opt out by returning `Err`.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There are only two crates you'll need if you want to use this with you project `
 Contains all of the important traits and structs that power our generated code, e.g. `Message` and `Lazy`. Include this as a `dependency`, e.g.
 ```
 [dependencies]
-pb-jelly = "0.0.9"
+pb-jelly = "0.0.10"
 ```
 
 ##### `pb-jelly-gen`
@@ -75,7 +75,7 @@ You'll need to add a generation crate (see `examples_gen` for an example)
 Include `pb-jelly-gen` as a dependency of your generation crate, and `cargo run` to invoke protoc for you.
 ```
 [dependencies]
-pb-jelly-gen = "0.0.9"
+pb-jelly-gen = "0.0.10"
 ```
 
 Eventually, we hope to eliminate the need for a generation crate, and simply have generation occur

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 bytes = "1.0"
-pb-jelly = "0.0.9"
+pb-jelly = "0.0.10"
 proto_box_it = { path = "gen/rust/proto/proto_box_it" }
 proto_custom_type = { path = "gen/rust/proto/proto_custom_type" }
 proto_linked_list = { path = "gen/rust/proto/proto_linked_list" }

--- a/examples/examples_gen/Cargo.toml
+++ b/examples/examples_gen/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.9"  # If copying this example - use this
+#pb-jelly-gen = "0.0.10"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }

--- a/pb-jelly-gen/Cargo.toml
+++ b/pb-jelly-gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pb-jelly-gen"
 description = "A protobuf binding generation framework for the Rust language developed at Dropbox"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/pb-jelly-gen/README.md
+++ b/pb-jelly-gen/README.md
@@ -18,7 +18,7 @@ Once you've completed the above steps, you should include this crate as a build-
 ##### `Cargo.toml`
 ```
 [build-dependencies]
-pb-jelly-gen = "0.0.9"
+pb-jelly-gen = "0.0.10"
 ```
 
 ##### `build.rs`

--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1789,7 +1789,7 @@ class Context(object):
             features = {u"serde": u' features = ["serde_derive"]'}
             versions = {
                 u"lazy_static": u' version = "1.4.0" ',
-                u"pb-jelly": u' version = "0.0.9" ',
+                u"pb-jelly": u' version = "0.0.10" ',
                 u"serde": u' version = "1.0" ',
                 u"bytes": u' version = "1.0" ',
             }

--- a/pb-test/Cargo.toml
+++ b/pb-test/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "1.0"
-pb-jelly = "0.0.9"
+pb-jelly = "0.0.10"
 pretty_assertions = "0.6.1"
 proto_pbtest = { path = "gen/pb-jelly/proto_pbtest" }
 walkdir = "2.3.1"

--- a/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.9" }
+pb-jelly = { version = "0.0.10" }

--- a/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.9" }
+pb-jelly = { version = "0.0.10" }

--- a/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 bytes = { version = "1.0" }
 lazy_static = { version = "1.4.0" }
-pb-jelly = { version = "0.0.9" }
+pb-jelly = { version = "0.0.10" }
 proto_google = {path = "../proto_google"}

--- a/pb-test/pb_test_gen/Cargo.toml
+++ b/pb-test/pb_test_gen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.9"  # If copying this example - use this
+#pb-jelly-gen = "0.0.10"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }
 
 # only used when benchmarking PROST!


### PR DESCRIPTION
This PR updates pb-jelly-gen to v0.0.10, updates the `CHANGELOG`, tests, and examples