### PR TITLE
Fix clippy, add workflow to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           components: rustfmt
       - name: Run rustfmt
         run: ci/run_rustfmt.sh
+
   black:
     name: Run black formatter on codegen.py
     runs-on: ubuntu-latest
@@ -27,6 +28,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/checkout@v2
       - run: ci/run_black.sh
+
   mypy:
     name: Run mypy on codegen.py
     runs-on: ubuntu-latest
@@ -39,6 +41,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/checkout@v2
       - run: ci/run_mypy.sh
+
   pb-jelly-unit:
     name: pb-jelly unit tests
     runs-on: ubuntu-latest
@@ -53,6 +56,7 @@ jobs:
         run: |
           cd pb-jelly
           cargo test
+
   pb-jelly-gen-unit:
     name: pb-jelly-gen unit tests
     runs-on: ubuntu-latest
@@ -67,6 +71,7 @@ jobs:
         run: |
           cd pb-jelly-gen
           cargo test
+
   pbtest:
     strategy:
       matrix:
@@ -94,6 +99,7 @@ jobs:
           cargo run
           cd ..
           cargo test
+
   examples:
     name: examples
     runs-on: ubuntu-latest
@@ -116,6 +122,7 @@ jobs:
           cargo run
           cd ..
           cargo test
+
   benchmarks:
     name: benchmarks
     runs-on: ubuntu-latest
@@ -138,3 +145,29 @@ jobs:
           cargo run --features=bench_prost,bench_rust_protobuf
           cd ..
           cargo bench bench --features=bench_prost,bench_rust_protobuf
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - run: rustup component add clippy
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: ${{env.PROTOBUF_VER}}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run clippy
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: |
+          cd pb-test/pb_test_gen
+          cargo run
+          cd ../gen/pb-jelly/proto_pbtest
+          cargo clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,8 +146,8 @@ jobs:
           cd ..
           cargo bench bench --features=bench_prost,bench_rust_protobuf
 
-  clippy:
-    name: clippy
+  clippy_gen:
+    name: clippy gen
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Avoid unnecessary `return` statements in some generated code. (#136)
 * Avoid extra logic for oneofs with only 1 possible value. (#133)
 
 # 0.0.10

--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -287,10 +287,14 @@ class RustType(object):
 
     def can_be_packed(self) -> bool:
         # Return true if incoming messages could be packed on the wire
-        return self.field.label == FieldDescriptorProto.LABEL_REPEATED and self.wire_format() in (
-            "Varint",
-            "Fixed64",
-            "Fixed32",
+        return (
+            self.field.label == FieldDescriptorProto.LABEL_REPEATED
+            and self.wire_format()
+            in (
+                "Varint",
+                "Fixed64",
+                "Fixed32",
+            )
         )
 
     def should_serialize_packed(self) -> bool:
@@ -1620,9 +1624,9 @@ class Context(object):
                 if msg_type.options.Extensions[extensions_pb2.preserve_unrecognized]:
                     assert field_type.typ.options.Extensions[
                         extensions_pb2.preserve_unrecognized
-                    ], (
-                        "%s preserves unrecognized but child message %s does not"
-                        % (fq_msg, field_fq_msg)
+                    ], "%s preserves unrecognized but child message %s does not" % (
+                        fq_msg,
+                        field_fq_msg,
                     )
 
                 self.calc_impls(

--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -287,14 +287,10 @@ class RustType(object):
 
     def can_be_packed(self) -> bool:
         # Return true if incoming messages could be packed on the wire
-        return (
-            self.field.label == FieldDescriptorProto.LABEL_REPEATED
-            and self.wire_format()
-            in (
-                "Varint",
-                "Fixed64",
-                "Fixed32",
-            )
+        return self.field.label == FieldDescriptorProto.LABEL_REPEATED and self.wire_format() in (
+            "Varint",
+            "Fixed64",
+            "Fixed32",
         )
 
     def should_serialize_packed(self) -> bool:
@@ -424,9 +420,7 @@ class RustType(object):
         elif self.field.type == FieldDescriptorProto.TYPE_ENUM:
             return self.rust_type(), "self.%s.unwrap_or_default()" % name
         elif self.field.type == FieldDescriptorProto.TYPE_MESSAGE:
-            deref = (
-                "" if not self.is_boxed() else ".map(::std::ops::Deref::deref)"
-            )
+            deref = "" if not self.is_boxed() else ".map(::std::ops::Deref::deref)"
             return (
                 "&" + self.rust_type(),
                 "self.%s.as_ref()%s.unwrap_or(&%s_default)"
@@ -1626,9 +1620,9 @@ class Context(object):
                 if msg_type.options.Extensions[extensions_pb2.preserve_unrecognized]:
                     assert field_type.typ.options.Extensions[
                         extensions_pb2.preserve_unrecognized
-                    ], "%s preserves unrecognized but child message %s does not" % (
-                        fq_msg,
-                        field_fq_msg,
+                    ], (
+                        "%s preserves unrecognized but child message %s does not"
+                        % (fq_msg, field_fq_msg)
                     )
 
                 self.calc_impls(

--- a/pb-test/gen/pb-jelly/proto_google/src/empty.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_google/src/empty.rs.expected
@@ -62,7 +62,7 @@ impl ::pb_jelly::Reflection for Empty {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }

--- a/pb-test/gen/pb-jelly/proto_google/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_google/src/lib.rs.expected
@@ -1,8 +1,6 @@
 // @generated, do not edit
 
 #![warn(rust_2018_idioms)]
-#![allow(clippy::float_cmp)]
-#![allow(clippy::module_inception)]
 #![allow(irrefutable_let_patterns)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -11,6 +9,17 @@
 #![allow(unused_variables)]
 #![allow(irrefutable_let_patterns)]
 #![allow(broken_intra_doc_links)]
+
+// Modules are generated based on the naming conventions of protobuf, which might cause "module inception"
+#![allow(clippy::module_inception)]
+// This is all generated code, so "manually" implementing derivable impls is okay
+#![allow(clippy::derivable_impls)]
+// For enums with many variants, the matches!(...) macro isn't obviously better
+#![allow(clippy::match_like_matches_macro)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::option_as_ref_deref)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::match_single_binding)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/lib.rs.expected
@@ -1,8 +1,6 @@
 // @generated, do not edit
 
 #![warn(rust_2018_idioms)]
-#![allow(clippy::float_cmp)]
-#![allow(clippy::module_inception)]
 #![allow(irrefutable_let_patterns)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -11,6 +9,17 @@
 #![allow(unused_variables)]
 #![allow(irrefutable_let_patterns)]
 #![allow(broken_intra_doc_links)]
+
+// Modules are generated based on the naming conventions of protobuf, which might cause "module inception"
+#![allow(clippy::module_inception)]
+// This is all generated code, so "manually" implementing derivable impls is okay
+#![allow(clippy::derivable_impls)]
+// For enums with many variants, the matches!(...) macro isn't obviously better
+#![allow(clippy::match_like_matches_macro)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::option_as_ref_deref)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::match_single_binding)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
@@ -94,10 +94,10 @@ impl ::pb_jelly::Reflection for NoPackage {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "field" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.field);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.field)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
@@ -103,10 +103,10 @@ impl ::pb_jelly::Reflection for BytesData {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "data" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.data.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.data.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -219,10 +219,10 @@ impl ::pb_jelly::Reflection for VecData {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "data" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.data.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.data.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -334,10 +334,10 @@ impl ::pb_jelly::Reflection for StringMessage {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "data" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.data.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.data.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
@@ -1,8 +1,6 @@
 // @generated, do not edit
 
 #![warn(rust_2018_idioms)]
-#![allow(clippy::float_cmp)]
-#![allow(clippy::module_inception)]
 #![allow(irrefutable_let_patterns)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -11,6 +9,17 @@
 #![allow(unused_variables)]
 #![allow(irrefutable_let_patterns)]
 #![allow(broken_intra_doc_links)]
+
+// Modules are generated based on the naming conventions of protobuf, which might cause "module inception"
+#![allow(clippy::module_inception)]
+// This is all generated code, so "manually" implementing derivable impls is okay
+#![allow(clippy::derivable_impls)]
+// For enums with many variants, the matches!(...) macro isn't obviously better
+#![allow(clippy::match_like_matches_macro)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::option_as_ref_deref)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::match_single_binding)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -506,7 +506,7 @@ impl ::pb_jelly::Reflection for Option {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -568,7 +568,7 @@ impl ::pb_jelly::Reflection for Vec {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -630,7 +630,7 @@ impl ::pb_jelly::Reflection for Default {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -692,7 +692,7 @@ impl ::pb_jelly::Reflection for String {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -800,7 +800,7 @@ impl ::pb_jelly::Reflection for Version0OneOfNoneNullable {
         if let Version0OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
           return Some("string_one_of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -816,7 +816,7 @@ impl ::pb_jelly::Reflection for Version0OneOfNoneNullable {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -962,7 +962,7 @@ impl ::pb_jelly::Reflection for Version1OneOfNoneNullable {
         if let Version1OneOfNoneNullable_TestOneof::StringTwoOf(ref val) = self.test_oneof {
           return Some("string_two_of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -996,7 +996,7 @@ impl ::pb_jelly::Reflection for Version1OneOfNoneNullable {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1175,7 +1175,7 @@ impl ::pb_jelly::Reflection for Version2OneOfNoneNullable {
         if let Version2OneOfNoneNullable_TestOneof::IntOneOf(ref val) = self.test_oneof {
           return Some("int_one_Of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -1221,7 +1221,7 @@ impl ::pb_jelly::Reflection for Version2OneOfNoneNullable {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1325,10 +1325,10 @@ impl ::pb_jelly::Reflection for Version1Enum {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "enum_field" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.enum_field.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.enum_field.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1432,10 +1432,10 @@ impl ::pb_jelly::Reflection for Version2Enum {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "enum_field" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.enum_field.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.enum_field.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1538,7 +1538,7 @@ impl ::pb_jelly::Reflection for Version1OneOf {
         if let Some(Version1OneOf_TestOneof::StringOneOf(ref val)) = self.test_oneof {
           return Some("string_one_of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -1560,7 +1560,7 @@ impl ::pb_jelly::Reflection for Version1OneOf {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1696,7 +1696,7 @@ impl ::pb_jelly::Reflection for Version2OneOf {
         if let Some(Version2OneOf_TestOneof::IntOneOf(ref val)) = self.test_oneof {
           return Some("int_one_of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -1730,7 +1730,7 @@ impl ::pb_jelly::Reflection for Version2OneOf {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1842,10 +1842,10 @@ impl ::pb_jelly::Reflection for Version1 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "required_string" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.required_string.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.required_string.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -2493,49 +2493,49 @@ impl ::pb_jelly::Reflection for Version2 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "required_string" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.required_string.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.required_string.get_or_insert_with(::std::default::Default::default))
       }
       "optional_int32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_int32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_int32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_int64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_int64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_int64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_uint32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_uint32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_uint32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_uint64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_uint64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_uint64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_fixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_fixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_sfixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_sfixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_double" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_double.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_double.get_or_insert_with(::std::default::Default::default))
       }
       "optional_bool" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_bool.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_bool.get_or_insert_with(::std::default::Default::default))
       }
       "optional_string" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_string.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_string.get_or_insert_with(::std::default::Default::default))
       }
       "optional_bytes" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_bytes.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_bytes.get_or_insert_with(::std::default::Default::default))
       }
       "optional_float" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_float.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_float.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -2639,10 +2639,10 @@ impl ::pb_jelly::Reflection for ForeignMessage {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "c" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.c.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.c.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -3092,7 +3092,7 @@ impl TestMessage {
     self.optional_foreign_message_boxed.take().unwrap_or_default()
   }
   pub fn get_optional_foreign_message_boxed(&self) -> &ForeignMessage {
-    self.optional_foreign_message_boxed.as_ref().map(|v| ::std::ops::Deref::deref(v)).unwrap_or(&ForeignMessage_default)
+    self.optional_foreign_message_boxed.as_ref().map(::std::ops::Deref::deref).unwrap_or(&ForeignMessage_default)
   }
   pub fn has_type_(&self) -> bool {
     self.type_.is_some()
@@ -4992,7 +4992,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let Some(TestMessage_OneofInt::Foreign1(ref val)) = self.oneof_int {
           return Some("foreign1");
         }
-        return None;
+        None
       }
       "oneof_foreign" => {
         if let Some(TestMessage_OneofForeign::Int2(ref val)) = self.oneof_foreign {
@@ -5001,7 +5001,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let Some(TestMessage_OneofForeign::Foreign2(ref val)) = self.oneof_foreign {
           return Some("foreign2");
         }
-        return None;
+        None
       }
       "oneof_zero" => {
         if let Some(TestMessage_OneofZero::Int3(ref val)) = self.oneof_zero {
@@ -5010,7 +5010,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let Some(TestMessage_OneofZero::Foreign3(ref val)) = self.oneof_zero {
           return Some("foreign3");
         }
-        return None;
+        None
       }
       "oneof_null" => {
         if let Some(TestMessage_OneofNull::Int4(ref val)) = self.oneof_null {
@@ -5019,7 +5019,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let Some(TestMessage_OneofNull::Foreign4(ref val)) = self.oneof_null {
           return Some("foreign4");
         }
-        return None;
+        None
       }
       "oneof_unset" => {
         if let Some(TestMessage_OneofUnset::Int5(ref val)) = self.oneof_unset {
@@ -5028,7 +5028,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let Some(TestMessage_OneofUnset::Foreign5(ref val)) = self.oneof_unset {
           return Some("foreign5");
         }
-        return None;
+        None
       }
       "oneof_primitives" => {
         if let Some(TestMessage_OneofPrimitives::Int6(ref val)) = self.oneof_primitives {
@@ -5037,7 +5037,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let Some(TestMessage_OneofPrimitives::Bool6(ref val)) = self.oneof_primitives {
           return Some("bool6");
         }
-        return None;
+        None
       }
       "oneof_empty_field" => {
         if let TestMessage_OneofEmptyField::A = self.oneof_empty_field {
@@ -5051,7 +5051,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let TestMessage_OneofEmptyField::C(ref val) = self.oneof_empty_field {
           return Some("c");
         }
-        return None;
+        None
       }
       "mod_" => {
         if let Some(TestMessage_Mod::Loop(ref val)) = self.mod_ {
@@ -5060,7 +5060,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         if let Some(TestMessage_Mod::Unsafe(ref val)) = self.mod_ {
           return Some("unsafe_");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -5070,106 +5070,106 @@ impl ::pb_jelly::Reflection for TestMessage {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "optional_int32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_int32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_int32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_int64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_int64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_int64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_uint32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_uint32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_uint32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_uint64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_uint64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_uint64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_fixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_fixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_fixed32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_sfixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed64.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed64.get_or_insert_with(::std::default::Default::default))
       }
       "optional_sfixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed32.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_sfixed32.get_or_insert_with(::std::default::Default::default))
       }
       "optional_double" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_double.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_double.get_or_insert_with(::std::default::Default::default))
       }
       "optional_bool" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_bool.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_bool.get_or_insert_with(::std::default::Default::default))
       }
       "optional_string" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_string.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_string.get_or_insert_with(::std::default::Default::default))
       }
       "optional_bytes" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_bytes.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_bytes.get_or_insert_with(::std::default::Default::default))
       }
       "optional_float" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_float.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_float.get_or_insert_with(::std::default::Default::default))
       }
       "optional_foreign_message" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message.get_or_insert_with(::std::default::Default::default))
       }
       "optional_nested_enum" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_nested_enum.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_nested_enum.get_or_insert_with(::std::default::Default::default))
       }
       "optional_foreign_enum" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_enum.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_enum.get_or_insert_with(::std::default::Default::default))
       }
       "repeated_int32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_int64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_uint32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_uint64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_fixed64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_fixed32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_sfixed64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_sfixed32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_double" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_bool" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_string" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_bytes" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_float" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_foreign_message" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_nested_enum" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_foreign_enum" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "optional_foreign_message_boxed" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message_boxed.get_or_insert_with(::std::default::Default::default).as_mut());
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message_boxed.get_or_insert_with(::std::default::Default::default).as_mut())
       }
       "optional_foreign_message_nonnullable" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_foreign_message_nonnullable);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_foreign_message_nonnullable)
       }
       "int1" => {
         match self.oneof_int {
@@ -5322,7 +5322,7 @@ impl ::pb_jelly::Reflection for TestMessage {
             self.oneof_empty_field = TestMessage_OneofEmptyField::A;
           },
         }
-        return ::pb_jelly::reflection::FieldMut::Empty;
+        ::pb_jelly::reflection::FieldMut::Empty
       }
       "b" => {
         match self.oneof_empty_field {
@@ -5331,7 +5331,7 @@ impl ::pb_jelly::Reflection for TestMessage {
             self.oneof_empty_field = TestMessage_OneofEmptyField::B;
           },
         }
-        return ::pb_jelly::reflection::FieldMut::Empty;
+        ::pb_jelly::reflection::FieldMut::Empty
       }
       "c" => {
         match self.oneof_empty_field {
@@ -5346,7 +5346,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         unreachable!()
       }
       "type_" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.type_.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.type_.get_or_insert_with(::std::default::Default::default))
       }
       "loop_" => {
         match self.mod_ {
@@ -5373,7 +5373,7 @@ impl ::pb_jelly::Reflection for TestMessage {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -846,10 +846,10 @@ impl ::pb_jelly::Reflection for ForeignMessage3 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "c" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.c);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.c)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -993,7 +993,7 @@ impl ::pb_jelly::Reflection for Version31OneOfNoneNullable {
         if let Version31OneOfNoneNullable_TestOneof::StringTwoOf(ref val) = self.test_oneof {
           return Some("string_two_of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -1027,7 +1027,7 @@ impl ::pb_jelly::Reflection for Version31OneOfNoneNullable {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1204,7 +1204,7 @@ impl ::pb_jelly::Reflection for Version32OneOfNoneNullable {
         if let Version32OneOfNoneNullable_TestOneof::IntOneOf(ref val) = self.test_oneof {
           return Some("int_one_Of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -1250,7 +1250,7 @@ impl ::pb_jelly::Reflection for Version32OneOfNoneNullable {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1346,10 +1346,10 @@ impl ::pb_jelly::Reflection for Version31Enum {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "enum_field" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.enum_field);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.enum_field)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1445,10 +1445,10 @@ impl ::pb_jelly::Reflection for Version32Enum {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "enum_field" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.enum_field);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.enum_field)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1549,7 +1549,7 @@ impl ::pb_jelly::Reflection for Version31OneOf {
         if let Some(Version31OneOf_TestOneof::StringOneOf(ref val)) = self.test_oneof {
           return Some("string_one_of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -1571,7 +1571,7 @@ impl ::pb_jelly::Reflection for Version31OneOf {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1705,7 +1705,7 @@ impl ::pb_jelly::Reflection for Version32OneOf {
         if let Some(Version32OneOf_TestOneof::IntOneOf(ref val)) = self.test_oneof {
           return Some("int_one_of");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -1739,7 +1739,7 @@ impl ::pb_jelly::Reflection for Version32OneOf {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -1840,10 +1840,10 @@ impl ::pb_jelly::Reflection for Version31 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "optional_string1" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string1);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string1)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -2396,49 +2396,49 @@ impl ::pb_jelly::Reflection for Version32 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "optional_string1" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string1);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string1)
       }
       "optional_int32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int32)
       }
       "optional_int64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int64)
       }
       "optional_uint32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint32)
       }
       "optional_uint64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint64)
       }
       "optional_fixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed64)
       }
       "optional_fixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed32)
       }
       "optional_sfixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed64)
       }
       "optional_sfixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed32)
       }
       "optional_double" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_double);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_double)
       }
       "optional_bool" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bool);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bool)
       }
       "optional_string" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string)
       }
       "optional_bytes" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bytes);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bytes)
       }
       "optional_float" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_float);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_float)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -4866,7 +4866,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         if let Some(TestMessage3_OneofInt::Foreign1(ref val)) = self.oneof_int {
           return Some("foreign1");
         }
-        return None;
+        None
       }
       "oneof_foreign" => {
         if let Some(TestMessage3_OneofForeign::Int2(ref val)) = self.oneof_foreign {
@@ -4875,7 +4875,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         if let Some(TestMessage3_OneofForeign::Foreign2(ref val)) = self.oneof_foreign {
           return Some("foreign2");
         }
-        return None;
+        None
       }
       "oneof_zero" => {
         if let Some(TestMessage3_OneofZero::Int3(ref val)) = self.oneof_zero {
@@ -4884,7 +4884,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         if let Some(TestMessage3_OneofZero::Foreign3(ref val)) = self.oneof_zero {
           return Some("foreign3");
         }
-        return None;
+        None
       }
       "oneof_null" => {
         if let Some(TestMessage3_OneofNull::Int4(ref val)) = self.oneof_null {
@@ -4893,7 +4893,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         if let Some(TestMessage3_OneofNull::Foreign4(ref val)) = self.oneof_null {
           return Some("foreign4");
         }
-        return None;
+        None
       }
       "oneof_unset" => {
         if let Some(TestMessage3_OneofUnset::Int5(ref val)) = self.oneof_unset {
@@ -4902,7 +4902,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         if let Some(TestMessage3_OneofUnset::Foreign5(ref val)) = self.oneof_unset {
           return Some("foreign5");
         }
-        return None;
+        None
       }
       "oneof_primitives" => {
         if let Some(TestMessage3_OneofPrimitives::Int6(ref val)) = self.oneof_primitives {
@@ -4911,7 +4911,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         if let Some(TestMessage3_OneofPrimitives::Bool6(ref val)) = self.oneof_primitives {
           return Some("bool6");
         }
-        return None;
+        None
       }
       "oneof_empty_field" => {
         if let TestMessage3_OneofEmptyField::A = self.oneof_empty_field {
@@ -4925,7 +4925,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         if let TestMessage3_OneofEmptyField::C(ref val) = self.oneof_empty_field {
           return Some("c");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -4935,115 +4935,115 @@ impl ::pb_jelly::Reflection for TestMessage3 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "optional_int32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int32)
       }
       "optional_int64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_int64)
       }
       "optional_uint32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint32)
       }
       "optional_uint64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_uint64)
       }
       "optional_fixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed64)
       }
       "optional_fixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_fixed32)
       }
       "optional_sfixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed64)
       }
       "optional_sfixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_sfixed32)
       }
       "optional_double" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_double);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_double)
       }
       "optional_bool" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bool);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bool)
       }
       "optional_string" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_string)
       }
       "optional_bytes" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bytes);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_bytes)
       }
       "optional_float" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_float);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_float)
       }
       "optional_foreign_message" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message.get_or_insert_with(::std::default::Default::default))
       }
       "optional_nested_enum" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_nested_enum);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_nested_enum)
       }
       "optional_foreign_enum" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_foreign_enum);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_foreign_enum)
       }
       "repeated_int32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_int64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_uint32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_uint64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_fixed64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_fixed32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_sfixed64" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_sfixed32" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_double" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_bool" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_string" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_bytes" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_float" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_foreign_message" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_nested_enum" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "repeated_foreign_enum" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "proto2_msg" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.proto2_msg.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.proto2_msg.get_or_insert_with(::std::default::Default::default))
       }
       "proto2_msg_empty" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.proto2_msg_empty.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.proto2_msg_empty.get_or_insert_with(::std::default::Default::default))
       }
       "proto2_msg_missing" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.proto2_msg_missing.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.proto2_msg_missing.get_or_insert_with(::std::default::Default::default))
       }
       "optional_foreign_message_boxed" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message_boxed.get_or_insert_with(::std::default::Default::default).as_mut());
+        ::pb_jelly::reflection::FieldMut::Value(self.optional_foreign_message_boxed.get_or_insert_with(::std::default::Default::default).as_mut())
       }
       "optional_foreign_message_nonnullable" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_foreign_message_nonnullable);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.optional_foreign_message_nonnullable)
       }
       "int1" => {
         match self.oneof_int {
@@ -5196,7 +5196,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
             self.oneof_empty_field = TestMessage3_OneofEmptyField::A;
           },
         }
-        return ::pb_jelly::reflection::FieldMut::Empty;
+        ::pb_jelly::reflection::FieldMut::Empty
       }
       "b" => {
         match self.oneof_empty_field {
@@ -5205,7 +5205,7 @@ impl ::pb_jelly::Reflection for TestMessage3 {
             self.oneof_empty_field = TestMessage3_OneofEmptyField::B;
           },
         }
-        return ::pb_jelly::reflection::FieldMut::Empty;
+        ::pb_jelly::reflection::FieldMut::Empty
       }
       "c" => {
         match self.oneof_empty_field {
@@ -5220,28 +5220,28 @@ impl ::pb_jelly::Reflection for TestMessage3 {
         unreachable!()
       }
       "nested" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.nested);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.nested)
       }
       "nested_nullable" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.nested_nullable.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.nested_nullable.get_or_insert_with(::std::default::Default::default))
       }
       "nested_repeated" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "fixed_length" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.fixed_length);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.fixed_length)
       }
       "fixed_length_repeated" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "zero_or_fixed_length" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.zero_or_fixed_length);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.zero_or_fixed_length)
       }
       "zero_or_fixed_length_repeated" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -5451,7 +5451,7 @@ impl ::pb_jelly::Reflection for TestMessage3_NestedMessage {
         if let TestMessage3_NestedMessage_NestedOneof::N(ref val) = self.nested_oneof {
           return Some("n");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -5509,7 +5509,7 @@ impl ::pb_jelly::Reflection for TestMessage3_NestedMessage {
         unreachable!()
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -5641,13 +5641,13 @@ impl ::pb_jelly::Reflection for TestMessage3_NestedMessage_File {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "blocklist" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       "size" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.size);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.size)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -5707,7 +5707,7 @@ impl ::pb_jelly::Reflection for TestMessage3_NestedMessage_Dir {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -5875,7 +5875,7 @@ impl ::pb_jelly::Reflection for TestMessage3NonNullableOneof {
         if let TestMessage3NonNullableOneof_NonNullableOneof::B(ref val) = self.non_nullable_oneof {
           return Some("b");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -5909,10 +5909,10 @@ impl ::pb_jelly::Reflection for TestMessage3NonNullableOneof {
         unreachable!()
       }
       "other_field" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.other_field);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.other_field)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6007,10 +6007,10 @@ impl ::pb_jelly::Reflection for TestMessage3ErrIfDefaultEnum {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "field" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.field);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.field)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6142,7 +6142,7 @@ impl ::pb_jelly::Reflection for TestMessage3ErrIfDefaultEnumOneof {
         if let Some(TestMessage3ErrIfDefaultEnumOneof_Maybe::Something(ref val)) = self.maybe {
           return Some("something");
         }
-        return None;
+        None
       }
       _ => {
         panic!("unknown oneof name given");
@@ -6164,10 +6164,10 @@ impl ::pb_jelly::Reflection for TestMessage3ErrIfDefaultEnumOneof {
         unreachable!()
       }
       "nothing" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.nothing.get_or_insert_with(::std::default::Default::default));
+        ::pb_jelly::reflection::FieldMut::Value(self.nothing.get_or_insert_with(::std::default::Default::default))
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6283,10 +6283,10 @@ impl ::pb_jelly::Reflection for TestMessage3RepeatedErrIfDefaultEnum {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "field" => {
-        unimplemented!("Repeated fields are not currently supported.");
+        unimplemented!("Repeated fields are not currently supported.")
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6382,10 +6382,10 @@ impl ::pb_jelly::Reflection for TestMessage3ClosedEnum {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "value" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.value);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.value)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6481,10 +6481,10 @@ impl ::pb_jelly::Reflection for TestMessage3ClosedEnum2 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "value" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.value);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.value)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6585,10 +6585,10 @@ impl ::pb_jelly::Reflection for TestMessage3NonOptionalBoxedMessage {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "msg" => {
-        return ::pb_jelly::reflection::FieldMut::Value(self.msg.as_mut());
+        ::pb_jelly::reflection::FieldMut::Value(self.msg.as_mut())
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6689,10 +6689,10 @@ impl ::pb_jelly::Reflection for TestMessage3NonOptionalBoxedMessage_InnerMessage
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "name" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.name);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.name)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -6799,10 +6799,10 @@ impl ::pb_jelly::Reflection for TestPreserveUnrecognized1 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "string1" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.string1);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.string1)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -7361,49 +7361,49 @@ impl ::pb_jelly::Reflection for TestPreserveUnrecognized2 {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "a_string1" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_string1);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_string1)
       }
       "a_int32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_int32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_int32)
       }
       "a_int64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_int64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_int64)
       }
       "a_uint32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_uint32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_uint32)
       }
       "a_uint64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_uint64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_uint64)
       }
       "a_fixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_fixed64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_fixed64)
       }
       "a_fixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_fixed32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_fixed32)
       }
       "a_sfixed64" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_sfixed64);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_sfixed64)
       }
       "a_sfixed32" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_sfixed32);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_sfixed32)
       }
       "a_double" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_double);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_double)
       }
       "a_bool" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_bool);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_bool)
       }
       "a_string" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_string);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_string)
       }
       "a_bytes" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_bytes);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_bytes)
       }
       "a_float" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.a_float);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.a_float)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -7470,7 +7470,7 @@ impl ::pb_jelly::Reflection for TestPreserveUnrecognizedEmpty {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
@@ -89,10 +89,10 @@ impl ::pb_jelly::Reflection for InpMessage {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "i" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.i);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.i)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }
@@ -188,10 +188,10 @@ impl ::pb_jelly::Reflection for OutMessage {
   fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
     match field_name {
       "o" => {
-        return ::pb_jelly::reflection::FieldMut::Value(&mut self.o);
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.o)
       }
       _ => {
-        panic!("unknown field name given");
+        panic!("unknown field name given")
       }
     }
   }


### PR DESCRIPTION
This PR fixes #135, which is the presence of a clippy lint "unneeded 'return' statement". 

It also fixes and ignores a couple of other clippy lints, and then adds a clippy workflow to CI that runs on the generated code from `pb-test`