### PR TITLE
Const-ify the descriptor on Message

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -1012,7 +1012,9 @@ class CodeWriter(object):
         with block(self, "impl ::pb_jelly::Message for " + name):
             with block(
                 self,
-                "fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor>",
+                "const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> = ",
+                start=" (",
+                end=");",
             ):
                 name = "_".join(path + [msg_type.name])
                 full_name = (

--- a/pb-jelly/src/erased.rs
+++ b/pb-jelly/src/erased.rs
@@ -21,7 +21,7 @@ where
     T: ConcreteMessage,
 {
     fn erased_descriptor(&self) -> Option<MessageDescriptor> {
-        self.descriptor()
+        T::DESCRIPTOR
     }
 
     fn erased_compute_size(&self) -> usize {

--- a/pb-jelly/src/lib.rs
+++ b/pb-jelly/src/lib.rs
@@ -68,10 +68,8 @@ mod tests;
 /// like string, bytes, etc. The exact details of this trait is implemented for messages
 /// and base types can be found at - <https://developers.google.com/protocol-buffers/docs/encoding>
 pub trait Message: PartialEq + Default + Debug + Any {
-    /// Returns the `MessageDescriptor` for this message, if this is not a primitive type.
-    fn descriptor(&self) -> Option<MessageDescriptor> {
-        None
-    }
+    /// The `MessageDescriptor` for this message, if this is not a primitive type.
+    const DESCRIPTOR: Option<MessageDescriptor> = None;
 
     /// Computes the number of bytes a message will take when serialized. This does not
     /// include number of bytes required for tag+wire_format or the bytes used to represent

--- a/pb-test/gen/pb-jelly/proto_google/src/empty.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_google/src/empty.rs.expected
@@ -21,7 +21,7 @@ lazy_static! {
   pub static ref Empty_default: Empty = Empty::default();
 }
 impl ::pb_jelly::Message for Empty {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Empty",
       full_name: "google.protobuf.Empty",
@@ -30,7 +30,7 @@ impl ::pb_jelly::Message for Empty {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     0
   }

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
@@ -14,7 +14,7 @@ lazy_static! {
   pub static ref NoPackage_default: NoPackage = NoPackage::default();
 }
 impl ::pb_jelly::Message for NoPackage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "NoPackage",
       full_name: "NoPackage",
@@ -32,7 +32,7 @@ impl ::pb_jelly::Message for NoPackage {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut field_size = 0;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
@@ -26,7 +26,7 @@ lazy_static! {
   pub static ref BytesData_default: BytesData = BytesData::default();
 }
 impl ::pb_jelly::Message for BytesData {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "BytesData",
       full_name: "pbtest.BytesData",
@@ -44,7 +44,7 @@ impl ::pb_jelly::Message for BytesData {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut data_size = 0;
@@ -142,7 +142,7 @@ lazy_static! {
   pub static ref VecData_default: VecData = VecData::default();
 }
 impl ::pb_jelly::Message for VecData {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "VecData",
       full_name: "pbtest.VecData",
@@ -160,7 +160,7 @@ impl ::pb_jelly::Message for VecData {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut data_size = 0;
@@ -257,7 +257,7 @@ lazy_static! {
   pub static ref StringMessage_default: StringMessage = StringMessage::default();
 }
 impl ::pb_jelly::Message for StringMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "StringMessage",
       full_name: "pbtest.StringMessage",
@@ -275,7 +275,7 @@ impl ::pb_jelly::Message for StringMessage {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut data_size = 0;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -465,7 +465,7 @@ lazy_static! {
   pub static ref Option_default: Option = Option::default();
 }
 impl ::pb_jelly::Message for Option {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Option",
       full_name: "pbtest.Option",
@@ -474,7 +474,7 @@ impl ::pb_jelly::Message for Option {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     0
   }
@@ -527,7 +527,7 @@ lazy_static! {
   pub static ref Vec_default: Vec = Vec::default();
 }
 impl ::pb_jelly::Message for Vec {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Vec",
       full_name: "pbtest.Vec",
@@ -536,7 +536,7 @@ impl ::pb_jelly::Message for Vec {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     0
   }
@@ -589,7 +589,7 @@ lazy_static! {
   pub static ref Default_default: Default = Default::default();
 }
 impl ::pb_jelly::Message for Default {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Default",
       full_name: "pbtest.Default",
@@ -598,7 +598,7 @@ impl ::pb_jelly::Message for Default {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     0
   }
@@ -651,7 +651,7 @@ lazy_static! {
   pub static ref String_default: String = String::default();
 }
 impl ::pb_jelly::Message for String {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "String",
       full_name: "pbtest.String",
@@ -660,7 +660,7 @@ impl ::pb_jelly::Message for String {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     0
   }
@@ -719,7 +719,7 @@ lazy_static! {
   pub static ref Version0OneOfNoneNullable_default: Version0OneOfNoneNullable = Version0OneOfNoneNullable::default();
 }
 impl ::pb_jelly::Message for Version0OneOfNoneNullable {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version0OneOfNoneNullable",
       full_name: "pbtest.Version0OneOfNoneNullable",
@@ -740,7 +740,7 @@ impl ::pb_jelly::Message for Version0OneOfNoneNullable {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -844,7 +844,7 @@ lazy_static! {
   pub static ref Version1OneOfNoneNullable_default: Version1OneOfNoneNullable = Version1OneOfNoneNullable::default();
 }
 impl ::pb_jelly::Message for Version1OneOfNoneNullable {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version1OneOfNoneNullable",
       full_name: "pbtest.Version1OneOfNoneNullable",
@@ -874,7 +874,7 @@ impl ::pb_jelly::Message for Version1OneOfNoneNullable {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1025,7 +1025,7 @@ lazy_static! {
   pub static ref Version2OneOfNoneNullable_default: Version2OneOfNoneNullable = Version2OneOfNoneNullable::default();
 }
 impl ::pb_jelly::Message for Version2OneOfNoneNullable {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version2OneOfNoneNullable",
       full_name: "pbtest.Version2OneOfNoneNullable",
@@ -1064,7 +1064,7 @@ impl ::pb_jelly::Message for Version2OneOfNoneNullable {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1253,7 +1253,7 @@ lazy_static! {
   pub static ref Version1Enum_default: Version1Enum = Version1Enum::default();
 }
 impl ::pb_jelly::Message for Version1Enum {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version1Enum",
       full_name: "pbtest.Version1Enum",
@@ -1271,7 +1271,7 @@ impl ::pb_jelly::Message for Version1Enum {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut enum_field_size = 0;
@@ -1360,7 +1360,7 @@ lazy_static! {
   pub static ref Version2Enum_default: Version2Enum = Version2Enum::default();
 }
 impl ::pb_jelly::Message for Version2Enum {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version2Enum",
       full_name: "pbtest.Version2Enum",
@@ -1378,7 +1378,7 @@ impl ::pb_jelly::Message for Version2Enum {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut enum_field_size = 0;
@@ -1462,7 +1462,7 @@ lazy_static! {
   pub static ref Version1OneOf_default: Version1OneOf = Version1OneOf::default();
 }
 impl ::pb_jelly::Message for Version1OneOf {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version1OneOf",
       full_name: "pbtest.Version1OneOf",
@@ -1483,7 +1483,7 @@ impl ::pb_jelly::Message for Version1OneOf {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1588,7 +1588,7 @@ lazy_static! {
   pub static ref Version2OneOf_default: Version2OneOf = Version2OneOf::default();
 }
 impl ::pb_jelly::Message for Version2OneOf {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version2OneOf",
       full_name: "pbtest.Version2OneOf",
@@ -1618,7 +1618,7 @@ impl ::pb_jelly::Message for Version2OneOf {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1765,7 +1765,7 @@ lazy_static! {
   pub static ref Version1_default: Version1 = Version1::default();
 }
 impl ::pb_jelly::Message for Version1 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version1",
       full_name: "pbtest.Version1",
@@ -1783,7 +1783,7 @@ impl ::pb_jelly::Message for Version1 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut required_string_size = 0;
@@ -2029,7 +2029,7 @@ lazy_static! {
   pub static ref Version2_default: Version2 = Version2::default();
 }
 impl ::pb_jelly::Message for Version2 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version2",
       full_name: "pbtest.Version2",
@@ -2164,7 +2164,7 @@ impl ::pb_jelly::Message for Version2 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut required_string_size = 0;
@@ -2567,7 +2567,7 @@ lazy_static! {
   pub static ref ForeignMessage_default: ForeignMessage = ForeignMessage::default();
 }
 impl ::pb_jelly::Message for ForeignMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "ForeignMessage",
       full_name: "pbtest.ForeignMessage",
@@ -2585,7 +2585,7 @@ impl ::pb_jelly::Message for ForeignMessage {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut c_size = 0;
@@ -3157,7 +3157,7 @@ lazy_static! {
   pub static ref TestMessage_default: TestMessage = TestMessage::default();
 }
 impl ::pb_jelly::Message for TestMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage",
       full_name: "pbtest.TestMessage",
@@ -3658,7 +3658,7 @@ impl ::pb_jelly::Message for TestMessage {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut optional_int32_size = 0;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -771,7 +771,7 @@ lazy_static! {
   pub static ref ForeignMessage3_default: ForeignMessage3 = ForeignMessage3::default();
 }
 impl ::pb_jelly::Message for ForeignMessage3 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "ForeignMessage3",
       full_name: "pbtest.ForeignMessage3",
@@ -789,7 +789,7 @@ impl ::pb_jelly::Message for ForeignMessage3 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut c_size = 0;
@@ -875,7 +875,7 @@ lazy_static! {
   pub static ref Version31OneOfNoneNullable_default: Version31OneOfNoneNullable = Version31OneOfNoneNullable::default();
 }
 impl ::pb_jelly::Message for Version31OneOfNoneNullable {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version31OneOfNoneNullable",
       full_name: "pbtest.Version31OneOfNoneNullable",
@@ -905,7 +905,7 @@ impl ::pb_jelly::Message for Version31OneOfNoneNullable {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1054,7 +1054,7 @@ lazy_static! {
   pub static ref Version32OneOfNoneNullable_default: Version32OneOfNoneNullable = Version32OneOfNoneNullable::default();
 }
 impl ::pb_jelly::Message for Version32OneOfNoneNullable {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version32OneOfNoneNullable",
       full_name: "pbtest.Version32OneOfNoneNullable",
@@ -1093,7 +1093,7 @@ impl ::pb_jelly::Message for Version32OneOfNoneNullable {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1271,7 +1271,7 @@ lazy_static! {
   pub static ref Version31Enum_default: Version31Enum = Version31Enum::default();
 }
 impl ::pb_jelly::Message for Version31Enum {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version31Enum",
       full_name: "pbtest.Version31Enum",
@@ -1289,7 +1289,7 @@ impl ::pb_jelly::Message for Version31Enum {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut enum_field_size = 0;
@@ -1370,7 +1370,7 @@ lazy_static! {
   pub static ref Version32Enum_default: Version32Enum = Version32Enum::default();
 }
 impl ::pb_jelly::Message for Version32Enum {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version32Enum",
       full_name: "pbtest.Version32Enum",
@@ -1388,7 +1388,7 @@ impl ::pb_jelly::Message for Version32Enum {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut enum_field_size = 0;
@@ -1473,7 +1473,7 @@ lazy_static! {
   pub static ref Version31OneOf_default: Version31OneOf = Version31OneOf::default();
 }
 impl ::pb_jelly::Message for Version31OneOf {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version31OneOf",
       full_name: "pbtest.Version31OneOf",
@@ -1494,7 +1494,7 @@ impl ::pb_jelly::Message for Version31OneOf {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1597,7 +1597,7 @@ lazy_static! {
   pub static ref Version32OneOf_default: Version32OneOf = Version32OneOf::default();
 }
 impl ::pb_jelly::Message for Version32OneOf {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version32OneOf",
       full_name: "pbtest.Version32OneOf",
@@ -1627,7 +1627,7 @@ impl ::pb_jelly::Message for Version32OneOf {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string_one_of_size = 0;
@@ -1760,7 +1760,7 @@ lazy_static! {
   pub static ref Version31_default: Version31 = Version31::default();
 }
 impl ::pb_jelly::Message for Version31 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version31",
       full_name: "pbtest.Version31",
@@ -1778,7 +1778,7 @@ impl ::pb_jelly::Message for Version31 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut optional_string1_size = 0;
@@ -1890,7 +1890,7 @@ lazy_static! {
   pub static ref Version32_default: Version32 = Version32::default();
 }
 impl ::pb_jelly::Message for Version32 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "Version32",
       full_name: "pbtest.Version32",
@@ -2025,7 +2025,7 @@ impl ::pb_jelly::Message for Version32 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut optional_string1_size = 0;
@@ -2597,7 +2597,7 @@ lazy_static! {
   pub static ref TestMessage3_default: TestMessage3 = TestMessage3::default();
 }
 impl ::pb_jelly::Message for TestMessage3 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3",
       full_name: "pbtest.TestMessage3",
@@ -3158,7 +3158,7 @@ impl ::pb_jelly::Message for TestMessage3 {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut optional_int32_size = 0;
@@ -5269,7 +5269,7 @@ lazy_static! {
   pub static ref TestMessage3_NestedMessage_default: TestMessage3_NestedMessage = TestMessage3_NestedMessage::default();
 }
 impl ::pb_jelly::Message for TestMessage3_NestedMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3_NestedMessage",
       full_name: "pbtest.TestMessage3_NestedMessage",
@@ -5317,7 +5317,7 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut f_size = 0;
@@ -5532,7 +5532,7 @@ lazy_static! {
   pub static ref TestMessage3_NestedMessage_File_default: TestMessage3_NestedMessage_File = TestMessage3_NestedMessage_File::default();
 }
 impl ::pb_jelly::Message for TestMessage3_NestedMessage_File {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3_NestedMessage_File",
       full_name: "pbtest.TestMessage3_NestedMessage_File",
@@ -5559,7 +5559,7 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage_File {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut blocklist_size = 0;
@@ -5666,7 +5666,7 @@ lazy_static! {
   pub static ref TestMessage3_NestedMessage_Dir_default: TestMessage3_NestedMessage_Dir = TestMessage3_NestedMessage_Dir::default();
 }
 impl ::pb_jelly::Message for TestMessage3_NestedMessage_Dir {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3_NestedMessage_Dir",
       full_name: "pbtest.TestMessage3_NestedMessage_Dir",
@@ -5675,7 +5675,7 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage_Dir {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     0
   }
@@ -5735,7 +5735,7 @@ lazy_static! {
   pub static ref TestMessage3NonNullableOneof_default: TestMessage3NonNullableOneof = TestMessage3NonNullableOneof::default();
 }
 impl ::pb_jelly::Message for TestMessage3NonNullableOneof {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3NonNullableOneof",
       full_name: "pbtest.TestMessage3NonNullableOneof",
@@ -5774,7 +5774,7 @@ impl ::pb_jelly::Message for TestMessage3NonNullableOneof {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut a_size = 0;
@@ -5933,7 +5933,7 @@ lazy_static! {
   pub static ref TestMessage3ErrIfDefaultEnum_default: TestMessage3ErrIfDefaultEnum = TestMessage3ErrIfDefaultEnum::default();
 }
 impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnum {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3ErrIfDefaultEnum",
       full_name: "pbtest.TestMessage3ErrIfDefaultEnum",
@@ -5951,7 +5951,7 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnum {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut field_size = 0;
@@ -6037,7 +6037,7 @@ lazy_static! {
   pub static ref TestMessage3ErrIfDefaultEnumOneof_default: TestMessage3ErrIfDefaultEnumOneof = TestMessage3ErrIfDefaultEnumOneof::default();
 }
 impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnumOneof {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3ErrIfDefaultEnumOneof",
       full_name: "pbtest.TestMessage3ErrIfDefaultEnumOneof",
@@ -6067,7 +6067,7 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnumOneof {
         },
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut something_size = 0;
@@ -6188,7 +6188,7 @@ lazy_static! {
   pub static ref TestMessage3RepeatedErrIfDefaultEnum_default: TestMessage3RepeatedErrIfDefaultEnum = TestMessage3RepeatedErrIfDefaultEnum::default();
 }
 impl ::pb_jelly::Message for TestMessage3RepeatedErrIfDefaultEnum {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3RepeatedErrIfDefaultEnum",
       full_name: "pbtest.TestMessage3RepeatedErrIfDefaultEnum",
@@ -6206,7 +6206,7 @@ impl ::pb_jelly::Message for TestMessage3RepeatedErrIfDefaultEnum {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut field_size = 0;
@@ -6307,7 +6307,7 @@ lazy_static! {
   pub static ref TestMessage3ClosedEnum_default: TestMessage3ClosedEnum = TestMessage3ClosedEnum::default();
 }
 impl ::pb_jelly::Message for TestMessage3ClosedEnum {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3ClosedEnum",
       full_name: "pbtest.TestMessage3ClosedEnum",
@@ -6325,7 +6325,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut value_size = 0;
@@ -6406,7 +6406,7 @@ lazy_static! {
   pub static ref TestMessage3ClosedEnum2_default: TestMessage3ClosedEnum2 = TestMessage3ClosedEnum2::default();
 }
 impl ::pb_jelly::Message for TestMessage3ClosedEnum2 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3ClosedEnum2",
       full_name: "pbtest.TestMessage3ClosedEnum2",
@@ -6424,7 +6424,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum2 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut value_size = 0;
@@ -6505,7 +6505,7 @@ lazy_static! {
   pub static ref TestMessage3NonOptionalBoxedMessage_default: TestMessage3NonOptionalBoxedMessage = TestMessage3NonOptionalBoxedMessage::default();
 }
 impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3NonOptionalBoxedMessage",
       full_name: "pbtest.TestMessage3NonOptionalBoxedMessage",
@@ -6523,7 +6523,7 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut msg_size = 0;
@@ -6609,7 +6609,7 @@ lazy_static! {
   pub static ref TestMessage3NonOptionalBoxedMessage_InnerMessage_default: TestMessage3NonOptionalBoxedMessage_InnerMessage = TestMessage3NonOptionalBoxedMessage_InnerMessage::default();
 }
 impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage_InnerMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestMessage3NonOptionalBoxedMessage_InnerMessage",
       full_name: "pbtest.TestMessage3NonOptionalBoxedMessage_InnerMessage",
@@ -6627,7 +6627,7 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage_InnerMessage {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut name_size = 0;
@@ -6715,7 +6715,7 @@ lazy_static! {
   pub static ref TestPreserveUnrecognized1_default: TestPreserveUnrecognized1 = TestPreserveUnrecognized1::default();
 }
 impl ::pb_jelly::Message for TestPreserveUnrecognized1 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestPreserveUnrecognized1",
       full_name: "pbtest.TestPreserveUnrecognized1",
@@ -6733,7 +6733,7 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized1 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut string1_size = 0;
@@ -6851,7 +6851,7 @@ lazy_static! {
   pub static ref TestPreserveUnrecognized2_default: TestPreserveUnrecognized2 = TestPreserveUnrecognized2::default();
 }
 impl ::pb_jelly::Message for TestPreserveUnrecognized2 {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestPreserveUnrecognized2",
       full_name: "pbtest.TestPreserveUnrecognized2",
@@ -6986,7 +6986,7 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized2 {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut a_string1_size = 0;
@@ -7424,7 +7424,7 @@ lazy_static! {
   pub static ref TestPreserveUnrecognizedEmpty_default: TestPreserveUnrecognizedEmpty = TestPreserveUnrecognizedEmpty::default();
 }
 impl ::pb_jelly::Message for TestPreserveUnrecognizedEmpty {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "TestPreserveUnrecognizedEmpty",
       full_name: "pbtest.TestPreserveUnrecognizedEmpty",
@@ -7433,7 +7433,7 @@ impl ::pb_jelly::Message for TestPreserveUnrecognizedEmpty {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     size += self._unrecognized.len();

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
@@ -14,7 +14,7 @@ lazy_static! {
   pub static ref InpMessage_default: InpMessage = InpMessage::default();
 }
 impl ::pb_jelly::Message for InpMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "InpMessage",
       full_name: "pbtest.InpMessage",
@@ -32,7 +32,7 @@ impl ::pb_jelly::Message for InpMessage {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut i_size = 0;
@@ -113,7 +113,7 @@ lazy_static! {
   pub static ref OutMessage_default: OutMessage = OutMessage::default();
 }
 impl ::pb_jelly::Message for OutMessage {
-  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+  const DESCRIPTOR: ::std::option::Option<::pb_jelly::MessageDescriptor> =  (
     Some(::pb_jelly::MessageDescriptor {
       name: "OutMessage",
       full_name: "pbtest.OutMessage",
@@ -131,7 +131,7 @@ impl ::pb_jelly::Message for OutMessage {
       oneofs: &[
       ],
     })
-  }
+  );
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut o_size = 0;

--- a/pb-test/src/pbtest.rs
+++ b/pb-test/src/pbtest.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use std::io::Cursor;
 use std::io::Read;
 
+use pb_jelly::erased::Message as ErasedMessage;
 use pb_jelly::reflection::FieldMut;
 use pb_jelly::wire_format::Type;
 use pb_jelly::{
@@ -340,8 +341,8 @@ fn all_fields_reflection3() {
     expected.zero_or_fixed_length_repeated = vec![None, Some([0, 1, 2, 3]), None, Some([4, 5, 6, 7])];
 
     let mut serialized: ::std::collections::HashMap<u32, ::std::vec::Vec<u8>> = ::std::collections::HashMap::new();
-    let oneofs = expected.descriptor().unwrap().oneofs;
-    for f in expected.descriptor().unwrap().fields {
+    let oneofs = expected.erased_descriptor().unwrap().oneofs;
+    for f in expected.erased_descriptor().unwrap().fields {
         if f.label == Label::Repeated {
             // Skip, repeated fields aren't currently supported.
             continue;
@@ -371,7 +372,7 @@ fn all_fields_reflection3() {
     deserialized.nested_repeated = expected.nested_repeated.clone();
     deserialized.fixed_length_repeated = expected.fixed_length_repeated.clone();
     deserialized.zero_or_fixed_length_repeated = expected.zero_or_fixed_length_repeated.clone();
-    for f in deserialized.descriptor().unwrap().fields {
+    for f in deserialized.erased_descriptor().unwrap().fields {
         if f.label == Label::Repeated {
             // Skip, repeated fields aren't currently supported.
             continue;


### PR DESCRIPTION
This makes it possible to use the descriptor from a const context.