### PR TITLE
Pass through UTF-8 decode errors in deserialize

### DIFF
--- a/pb-jelly/src/base_types.rs
+++ b/pb-jelly/src/base_types.rs
@@ -577,7 +577,7 @@ impl Message for String {
             // Success! We have valid UTF-8, we can forget our guard.
             Ok(_) => Ok(std::mem::forget(guard)),
             // Error! Our guard will be dropped, and the buffer will be cleared.
-            Err(_) => Err(std::io::ErrorKind::InvalidData.into()),
+            Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
         }
     }
 }


### PR DESCRIPTION
This allows slightly more useful information in the error message.