### PR TITLE
Use r# syntax for keywords instead of appending _

### DIFF
--- a/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
@@ -25,6 +25,7 @@
 extern crate lazy_static;
 
 pub mod bench;
+pub mod r#mod;
 pub mod pbtest2;
 pub mod pbtest3;
 pub mod servicepb;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/mod/mod.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/mod/mod.rs.expected
@@ -1,0 +1,3 @@
+// @generated, do not edit
+
+pub mod r#struct;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/mod/struct.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/mod/struct.rs.expected
@@ -1,0 +1,61 @@
+// @generated, do not edit
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Message {
+}
+impl ::std::default::Default for Message {
+  fn default() -> Self {
+    Message {
+    }
+  }
+}
+lazy_static! {
+  pub static ref Message_default: Message = Message::default();
+}
+impl ::pb_jelly::Message for Message {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "Message",
+      full_name: "pbtest.mod.Message",
+      fields: &[
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    0
+  }
+  fn compute_grpc_slices_size(&self) -> usize {
+    0
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for Message {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -2685,7 +2685,7 @@ pub struct TestMessage {
   pub optional_foreign_message_boxed: ::std::option::Option<::std::boxed::Box<ForeignMessage>>,
   pub optional_foreign_message_nonnullable: ForeignMessage,
   /// Use some rust reserved keywords
-  pub type_: ::std::option::Option<bool>,
+  pub r#type: ::std::option::Option<bool>,
   pub oneof_int: ::std::option::Option<TestMessage_OneofInt>,
   pub oneof_foreign: ::std::option::Option<TestMessage_OneofForeign>,
   pub oneof_zero: ::std::option::Option<TestMessage_OneofZero>,
@@ -2693,7 +2693,7 @@ pub struct TestMessage {
   pub oneof_unset: ::std::option::Option<TestMessage_OneofUnset>,
   pub oneof_primitives: ::std::option::Option<TestMessage_OneofPrimitives>,
   pub oneof_empty_field: TestMessage_OneofEmptyField,
-  pub mod_: ::std::option::Option<TestMessage_Mod>,
+  pub r#mod: ::std::option::Option<TestMessage_Mod>,
 }
 #[derive(Clone, Debug, PartialEq)]
 pub enum TestMessage_OneofInt {
@@ -3094,14 +3094,14 @@ impl TestMessage {
   pub fn get_optional_foreign_message_boxed(&self) -> &ForeignMessage {
     self.optional_foreign_message_boxed.as_ref().map(::std::ops::Deref::deref).unwrap_or(&ForeignMessage_default)
   }
-  pub fn has_type_(&self) -> bool {
-    self.type_.is_some()
+  pub fn has_type(&self) -> bool {
+    self.r#type.is_some()
   }
-  pub fn set_type_(&mut self, v: bool) {
-    self.type_ = Some(v);
+  pub fn set_type(&mut self, v: bool) {
+    self.r#type = Some(v);
   }
-  pub fn get_type_(&self) -> bool {
-    self.type_.unwrap_or(false)
+  pub fn get_type(&self) -> bool {
+    self.r#type.unwrap_or(false)
   }
 }
 impl ::std::default::Default for TestMessage {
@@ -3141,7 +3141,7 @@ impl ::std::default::Default for TestMessage {
       repeated_foreign_enum: ::std::default::Default::default(),
       optional_foreign_message_boxed: ::std::default::Default::default(),
       optional_foreign_message_nonnullable: ::std::default::Default::default(),
-      type_: ::std::default::Default::default(),
+      r#type: ::std::default::Default::default(),
       oneof_int: None,
       oneof_foreign: None,
       oneof_zero: None,
@@ -3149,7 +3149,7 @@ impl ::std::default::Default for TestMessage {
       oneof_unset: None,
       oneof_primitives: None,
       oneof_empty_field: TestMessage_OneofEmptyField::A,
-      mod_: None,
+      r#mod: None,
     }
   }
 }
@@ -3604,8 +3604,8 @@ impl ::pb_jelly::Message for TestMessage {
           oneof_index: Some(6),
         },
         ::pb_jelly::FieldDescriptor {
-          name: "type_",
-          full_name: "pbtest.TestMessage.type_",
+          name: "type",
+          full_name: "pbtest.TestMessage.type",
           index: 49,
           number: 73,
           typ: ::pb_jelly::wire_format::Type::Varint,
@@ -3613,8 +3613,8 @@ impl ::pb_jelly::Message for TestMessage {
           oneof_index: None,
         },
         ::pb_jelly::FieldDescriptor {
-          name: "loop_",
-          full_name: "pbtest.TestMessage.loop_",
+          name: "loop",
+          full_name: "pbtest.TestMessage.loop",
           index: 50,
           number: 74,
           typ: ::pb_jelly::wire_format::Type::Varint,
@@ -3622,8 +3622,8 @@ impl ::pb_jelly::Message for TestMessage {
           oneof_index: Some(7),
         },
         ::pb_jelly::FieldDescriptor {
-          name: "unsafe_",
-          full_name: "pbtest.TestMessage.unsafe_",
+          name: "unsafe",
+          full_name: "pbtest.TestMessage.unsafe",
           index: 51,
           number: 75,
           typ: ::pb_jelly::wire_format::Type::Varint,
@@ -3654,7 +3654,7 @@ impl ::pb_jelly::Message for TestMessage {
           name: "oneof_empty_field",
         },
         ::pb_jelly::OneofDescriptor {
-          name: "mod_",
+          name: "mod",
         },
       ],
     })
@@ -4023,27 +4023,27 @@ impl ::pb_jelly::Message for TestMessage {
       c_size += l;
     }
     size += c_size;
-    let mut type__size = 0;
-    for val in &self.type_ {
+    let mut type_size = 0;
+    for val in &self.r#type {
       let l = ::pb_jelly::Message::compute_size(val);
-      type__size += ::pb_jelly::wire_format::serialized_length(73);
-      type__size += l;
+      type_size += ::pb_jelly::wire_format::serialized_length(73);
+      type_size += l;
     }
-    size += type__size;
-    let mut loop__size = 0;
-    if let Some(TestMessage_Mod::Loop(ref val)) = self.mod_ {
+    size += type_size;
+    let mut loop_size = 0;
+    if let Some(TestMessage_Mod::Loop(ref val)) = self.r#mod {
       let l = ::pb_jelly::Message::compute_size(val);
-      loop__size += ::pb_jelly::wire_format::serialized_length(74);
-      loop__size += l;
+      loop_size += ::pb_jelly::wire_format::serialized_length(74);
+      loop_size += l;
     }
-    size += loop__size;
-    let mut unsafe__size = 0;
-    if let Some(TestMessage_Mod::Unsafe(ref val)) = self.mod_ {
+    size += loop_size;
+    let mut unsafe_size = 0;
+    if let Some(TestMessage_Mod::Unsafe(ref val)) = self.r#mod {
       let l = ::pb_jelly::Message::compute_size(val);
-      unsafe__size += ::pb_jelly::wire_format::serialized_length(75);
-      unsafe__size += l;
+      unsafe_size += ::pb_jelly::wire_format::serialized_length(75);
+      unsafe_size += l;
     }
-    size += unsafe__size;
+    size += unsafe_size;
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -4199,13 +4199,13 @@ impl ::pb_jelly::Message for TestMessage {
     if let TestMessage_OneofEmptyField::C(ref val) = self.oneof_empty_field {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.type_ {
+    for val in &self.r#type {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    if let Some(TestMessage_Mod::Loop(ref val)) = self.mod_ {
+    if let Some(TestMessage_Mod::Loop(ref val)) = self.r#mod {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    if let Some(TestMessage_Mod::Unsafe(ref val)) = self.mod_ {
+    if let Some(TestMessage_Mod::Unsafe(ref val)) = self.r#mod {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
@@ -4441,15 +4441,15 @@ impl ::pb_jelly::Message for TestMessage {
       ::pb_jelly::wire_format::write(72, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.type_ {
+    for val in &self.r#type {
       ::pb_jelly::wire_format::write(73, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    if let Some(TestMessage_Mod::Loop(ref val)) = self.mod_ {
+    if let Some(TestMessage_Mod::Loop(ref val)) = self.r#mod {
       ::pb_jelly::wire_format::write(74, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    if let Some(TestMessage_Mod::Unsafe(ref val)) = self.mod_ {
+    if let Some(TestMessage_Mod::Unsafe(ref val)) = self.r#mod {
       ::pb_jelly::wire_format::write(75, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
@@ -4956,19 +4956,19 @@ impl ::pb_jelly::Message for TestMessage {
           ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 73)?;
           let mut val: bool = ::std::default::Default::default();
           ::pb_jelly::Message::deserialize(&mut val, buf)?;
-          self.type_ = Some(val);
+          self.r#type = Some(val);
         }
         74 => {
           ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 74)?;
           let mut val: i32 = ::std::default::Default::default();
           ::pb_jelly::Message::deserialize(&mut val, buf)?;
-          self.mod_ = Some(TestMessage_Mod::Loop(val));
+          self.r#mod = Some(TestMessage_Mod::Loop(val));
         }
         75 => {
           ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 75)?;
           let mut val: i32 = ::std::default::Default::default();
           ::pb_jelly::Message::deserialize(&mut val, buf)?;
-          self.mod_ = Some(TestMessage_Mod::Unsafe(val));
+          self.r#mod = Some(TestMessage_Mod::Unsafe(val));
         }
         _ => {
           ::pb_jelly::skip(typ, &mut buf)?;
@@ -5053,12 +5053,12 @@ impl ::pb_jelly::Reflection for TestMessage {
         }
         None
       }
-      "mod_" => {
-        if let Some(TestMessage_Mod::Loop(ref val)) = self.mod_ {
-          return Some("loop_");
+      "mod" => {
+        if let Some(TestMessage_Mod::Loop(ref val)) = self.r#mod {
+          return Some("loop");
         }
-        if let Some(TestMessage_Mod::Unsafe(ref val)) = self.mod_ {
-          return Some("unsafe_");
+        if let Some(TestMessage_Mod::Unsafe(ref val)) = self.r#mod {
+          return Some("unsafe");
         }
         None
       }
@@ -5345,29 +5345,29 @@ impl ::pb_jelly::Reflection for TestMessage {
         }
         unreachable!()
       }
-      "type_" => {
-        ::pb_jelly::reflection::FieldMut::Value(self.type_.get_or_insert_with(::std::default::Default::default))
+      "type" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.r#type.get_or_insert_with(::std::default::Default::default))
       }
-      "loop_" => {
-        match self.mod_ {
+      "loop" => {
+        match self.r#mod {
           Some(TestMessage_Mod::Loop(_)) => (),
           _ => {
-            self.mod_ = Some(TestMessage_Mod::Loop(::std::default::Default::default()));
+            self.r#mod = Some(TestMessage_Mod::Loop(::std::default::Default::default()));
           },
         }
-        if let Some(TestMessage_Mod::Loop(ref mut val)) = self.mod_ {
+        if let Some(TestMessage_Mod::Loop(ref mut val)) = self.r#mod {
           return ::pb_jelly::reflection::FieldMut::Value(val);
         }
         unreachable!()
       }
-      "unsafe_" => {
-        match self.mod_ {
+      "unsafe" => {
+        match self.r#mod {
           Some(TestMessage_Mod::Unsafe(_)) => (),
           _ => {
-            self.mod_ = Some(TestMessage_Mod::Unsafe(::std::default::Default::default()));
+            self.r#mod = Some(TestMessage_Mod::Unsafe(::std::default::Default::default()));
           },
         }
-        if let Some(TestMessage_Mod::Unsafe(ref mut val)) = self.mod_ {
+        if let Some(TestMessage_Mod::Unsafe(ref mut val)) = self.r#mod {
           return ::pb_jelly::reflection::FieldMut::Value(val);
         }
         unreachable!()

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -9374,3 +9374,319 @@ impl ::pb_jelly::Reflection for RecursiveOneof {
   }
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct MentionsKeywordPath {
+  pub message: ::std::option::Option<super::r#mod::r#struct::Message>,
+}
+impl ::std::default::Default for MentionsKeywordPath {
+  fn default() -> Self {
+    MentionsKeywordPath {
+      message: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref MentionsKeywordPath_default: MentionsKeywordPath = MentionsKeywordPath::default();
+}
+impl ::pb_jelly::Message for MentionsKeywordPath {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "MentionsKeywordPath",
+      full_name: "pbtest.MentionsKeywordPath",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "message",
+          full_name: "pbtest.MentionsKeywordPath.message",
+          index: 0,
+          number: 1,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut message_size = 0;
+    for val in &self.message {
+      let l = ::pb_jelly::Message::compute_size(val);
+      message_size += ::pb_jelly::wire_format::serialized_length(1);
+      message_size += ::pb_jelly::varint::serialized_length(l as u64);
+      message_size += l;
+    }
+    size += message_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize {
+    let mut size = 0;
+    for val in &self.message {
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    for val in &self.message {
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MentionsKeywordPath", 1)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: super::r#mod::r#struct::Message = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.message = Some(val);
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for MentionsKeywordPath {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "message" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.message.get_or_insert_with(::std::default::Default::default))
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NonNullableOneofKeyword {
+  pub r#async: NonNullableOneofKeyword_Async,
+}
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum NonNullableOneofKeyword_Async {
+  A(i64),
+}
+impl ::std::default::Default for NonNullableOneofKeyword {
+  fn default() -> Self {
+    NonNullableOneofKeyword {
+      r#async: NonNullableOneofKeyword_Async::A(::std::default::Default::default()),
+    }
+  }
+}
+lazy_static! {
+  pub static ref NonNullableOneofKeyword_default: NonNullableOneofKeyword = NonNullableOneofKeyword::default();
+}
+impl ::pb_jelly::Message for NonNullableOneofKeyword {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "NonNullableOneofKeyword",
+      full_name: "pbtest.NonNullableOneofKeyword",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "a",
+          full_name: "pbtest.NonNullableOneofKeyword.a",
+          index: 0,
+          number: 1,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: Some(0),
+        },
+      ],
+      oneofs: &[
+        ::pb_jelly::OneofDescriptor {
+          name: "async",
+        },
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut a_size = 0;
+    if let NonNullableOneofKeyword_Async::A(ref val) = self.r#async {
+      let l = ::pb_jelly::Message::compute_size(val);
+      a_size += ::pb_jelly::wire_format::serialized_length(1);
+      a_size += l;
+    }
+    size += a_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize {
+    let mut size = 0;
+    if let NonNullableOneofKeyword_Async::A(ref val) = self.r#async {
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if let NonNullableOneofKeyword_Async::A(ref val) = self.r#async {
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    let mut oneof_async: ::std::option::Option<NonNullableOneofKeyword_Async> = None;
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "NonNullableOneofKeyword", 1)?;
+          let mut val: i64 = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          oneof_async = Some(NonNullableOneofKeyword_Async::A(val));
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    match oneof_async {
+      Some(v) => self.r#async = v,
+      None => return Err(::std::io::Error::new(::std::io::ErrorKind::InvalidInput, "missing value for non-nullable oneof 'async' while parsing message pbtest.NonNullableOneofKeyword")),
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for NonNullableOneofKeyword {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      "async" => {
+        if let NonNullableOneofKeyword_Async::A(ref val) = self.r#async {
+          return Some("a");
+        }
+        None
+      }
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "a" => {
+        if let NonNullableOneofKeyword_Async::A(ref mut val) = self.r#async {
+          return ::pb_jelly::reflection::FieldMut::Value(val);
+        }
+        unreachable!()
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NonNullableEnumKeyword {
+  pub r#enum: TestMessage3_NestedMessage_NonNullableEnum,
+}
+impl ::std::default::Default for NonNullableEnumKeyword {
+  fn default() -> Self {
+    NonNullableEnumKeyword {
+      r#enum: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref NonNullableEnumKeyword_default: NonNullableEnumKeyword = NonNullableEnumKeyword::default();
+}
+impl ::pb_jelly::Message for NonNullableEnumKeyword {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "NonNullableEnumKeyword",
+      full_name: "pbtest.NonNullableEnumKeyword",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "enum",
+          full_name: "pbtest.NonNullableEnumKeyword.enum",
+          index: 0,
+          number: 1,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut enum_size = 0;
+    let val = &self.r#enum;
+    let l = ::pb_jelly::Message::compute_size(val);
+    enum_size += ::pb_jelly::wire_format::serialized_length(1);
+    enum_size += l;
+    size += enum_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize {
+    let mut size = 0;
+    let val = &self.r#enum;
+    size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    let val = &self.r#enum;
+    ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
+    ::pb_jelly::Message::serialize(val, w)?;
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    let mut r#enum: ::std::option::Option<TestMessage3_NestedMessage_NonNullableEnum> = None;
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "NonNullableEnumKeyword", 1)?;
+          let mut val: TestMessage3_NestedMessage_NonNullableEnum = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          r#enum = Some(val);
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    match r#enum {
+      Some(v) => self.r#enum = v,
+      None => return Err(::std::io::Error::new(::std::io::ErrorKind::InvalidInput, "err_if_default_or_unknown 'enum' had no value while parsing message pbtest.NonNullableEnumKeyword")),
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for NonNullableEnumKeyword {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "enum" => {
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.r#enum)
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+

--- a/pb-test/proto/packages/pbtest/mod/struct.proto
+++ b/pb-test/proto/packages/pbtest/mod/struct.proto
@@ -1,0 +1,5 @@
+syntax="proto3";
+
+package pbtest.mod;
+
+message Message {}

--- a/pb-test/proto/packages/pbtest/pbtest3.proto
+++ b/pb-test/proto/packages/pbtest/pbtest3.proto
@@ -2,6 +2,7 @@ syntax="proto3";
 
 import "google/protobuf/empty.proto";
 import "pbtest/pbtest2.proto";
+import "pbtest/mod/struct.proto";
 import "rust/extensions.proto";
 
 package pbtest;
@@ -367,4 +368,19 @@ message RecursiveOneof {
         ForeignMessage3 not_boxed = 4;
         ForeignMessage3 boxed = 5 [(rust.box_it) = true];
     }
+}
+
+message MentionsKeywordPath {
+    pbtest.mod.Message message = 1;
+}
+
+message NonNullableOneofKeyword {
+    oneof async {
+        option (rust.nullable) = false;
+        int64 a = 1;
+    }
+}
+
+message NonNullableEnumKeyword {
+    TestMessage3.NestedMessage.NonNullableEnum enum = 1;
 }

--- a/pb-test/src/pbtest.rs
+++ b/pb-test/src/pbtest.rs
@@ -178,9 +178,9 @@ fn all_fields() {
     expected.oneof_empty_field = TestMessage_OneofEmptyField::C(33);
     expected.oneof_empty_field = TestMessage_OneofEmptyField::B;
     expected.oneof_empty_field = TestMessage_OneofEmptyField::A;
-    expected.type_ = Some(false);
-    expected.mod_ = Some(TestMessage_Mod::Unsafe(3));
-    expected.mod_ = Some(TestMessage_Mod::Loop(3));
+    expected.r#type = Some(false);
+    expected.r#mod = Some(TestMessage_Mod::Unsafe(3));
+    expected.r#mod = Some(TestMessage_Mod::Loop(3));
 
     succeeds(&buf[..], expected)
 }

--- a/pb-test/src/verify_generated_files.rs
+++ b/pb-test/src/verify_generated_files.rs
@@ -23,7 +23,7 @@ fn verify_generated_files() {
 
     // Assert the correct number of pb-test generated files
     // Developers - please change this number if the change is intentional
-    assert_eq!(proto_files.len(), 13);
+    assert_eq!(proto_files.len(), 15);
 
     // Assert contents of the generated files
     for proto_file in proto_files {


### PR DESCRIPTION
This is more faithful to the input and guarantees that there can't be a collision. Also included is a fix for reflection since the munged names shouldn't be used at runtime.

This also adds a couple missing keywords from Rust 2018.