### PR TITLE
Smallen codegen

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -697,6 +697,13 @@ def field_iter(
             else:
                 ctx.write("let %s = &self.%s;" % (var, escape_name(field.name)))
             yield
+    elif typ.is_nullable() and not typ.is_repeated():
+        with block(
+            ctx, "if let Some(ref %s) = self.%s" % (var, escape_name(field.name))
+        ):
+            if typ.is_boxed():
+                ctx.write("let %s = &**%s;" % (var, var))
+            yield
     else:
         with block(ctx, "for %s in &self.%s" % (var, escape_name(field.name))):
             if typ.is_boxed():

--- a/pb-jelly/src/base_types.rs
+++ b/pb-jelly/src/base_types.rs
@@ -49,10 +49,17 @@ pub trait ClosedProtoEnum: ProtoEnum + Debug {
 ///
 /// Note that this is *not* a closed enum.
 pub trait OpenProtoEnum: ProtoEnum {
+    type Closed: ClosedProtoEnum;
+    /// If this is a known variant, returns the corresponding closed enum value.
+    fn into_known(self) -> Option<Self::Closed>;
     /// Get the name of this variant, if it is known.
-    fn name(self) -> Option<&'static str>;
-    /// Whether or not this enum variant is "known" (i.e. there is an associate constant with it).
-    fn is_known(self) -> bool;
+    fn name(self) -> Option<&'static str> {
+        self.into_known().map(<Self::Closed as ClosedProtoEnum>::name)
+    }
+    /// Whether or not this enum variant is "known" (i.e. there is an associated constant with it).
+    fn is_known(self) -> bool {
+        self.into_known().is_some()
+    }
 }
 
 /// Marker trait for proto enums.

--- a/pb-jelly/src/helpers.rs
+++ b/pb-jelly/src/helpers.rs
@@ -81,3 +81,16 @@ pub fn serialize_scalar<W: PbBufferWriter, T: Message>(
     }
     Ok(())
 }
+
+pub fn compute_size_scalar<T: Message>(val: &T, field_number: u32, wire_format: wire_format::Type) -> usize {
+    let mut size = 0;
+    if *val != T::default() {
+        size += wire_format::serialized_length(field_number);
+        let l = val.compute_size();
+        if let wire_format::Type::LengthDelimited = wire_format {
+            size += varint::serialized_length(l as u64);
+        }
+        size += l;
+    }
+    size
+}

--- a/pb-jelly/src/helpers.rs
+++ b/pb-jelly/src/helpers.rs
@@ -1,0 +1,65 @@
+use std::io;
+
+use crate::{
+    ensure_split,
+    ensure_wire_format,
+    varint,
+    wire_format,
+    Message,
+    PbBufferReader,
+};
+
+pub fn deserialize_packed<B: PbBufferReader, T: Message>(
+    buf: &mut B,
+    typ: wire_format::Type,
+    expected_wire_format: wire_format::Type,
+    msg_name: &'static str,
+    field_number: usize,
+    out: &mut Vec<T>,
+) -> io::Result<()> {
+    match typ {
+        wire_format::Type::LengthDelimited => {
+            let len = varint::ensure_read(buf)?;
+            let mut vals = ensure_split(buf, len as usize)?;
+            while vals.has_remaining() {
+                let mut val: T = Default::default();
+                val.deserialize(&mut vals)?;
+                out.push(val);
+            }
+        },
+        _ => {
+            ensure_wire_format(typ, expected_wire_format, msg_name, field_number)?;
+            let mut val: T = Default::default();
+            val.deserialize(buf)?;
+            out.push(val);
+        },
+    }
+    Ok(())
+}
+
+pub fn deserialize_length_delimited<B: PbBufferReader, T: Message>(
+    buf: &mut B,
+    typ: wire_format::Type,
+    msg_name: &'static str,
+    field_number: usize,
+) -> io::Result<T> {
+    ensure_wire_format(typ, wire_format::Type::LengthDelimited, msg_name, field_number)?;
+    let len = varint::ensure_read(buf)?;
+    let mut next = ensure_split(buf, len as usize)?;
+    let mut val: T = Default::default();
+    val.deserialize(&mut next)?;
+    Ok(val)
+}
+
+pub fn deserialize_known_length<B: PbBufferReader, T: Message>(
+    buf: &mut B,
+    typ: wire_format::Type,
+    expected_wire_format: wire_format::Type,
+    msg_name: &'static str,
+    field_number: usize,
+) -> io::Result<T> {
+    ensure_wire_format(typ, expected_wire_format, msg_name, field_number)?;
+    let mut val: T = Default::default();
+    val.deserialize(buf)?;
+    Ok(val)
+}

--- a/pb-jelly/src/lib.rs
+++ b/pb-jelly/src/lib.rs
@@ -24,6 +24,7 @@ use bytes::buf::{
 };
 
 pub mod erased;
+pub mod helpers;
 pub mod varint;
 pub mod wire_format;
 

--- a/pb-test/gen/pb-jelly/proto_google/src/protobuf/empty.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_google/src/protobuf/empty.rs.expected
@@ -34,9 +34,6 @@ impl ::pb_jelly::Message for Empty {
   fn compute_size(&self) -> usize {
     0
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    0
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     Ok(())
   }

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
@@ -38,14 +38,6 @@ impl ::pb_jelly::Message for NoPackage {
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.field, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.field != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.field;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.field, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
@@ -55,13 +55,7 @@ impl ::pb_jelly::Message for NoPackage {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.field != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.field;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.field, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
@@ -68,11 +68,7 @@ impl ::pb_jelly::Message for NoPackage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "NoPackage", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "NoPackage", 1)?;
           self.field = val;
         }
         _ => {

--- a/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/src/proto_nopackage.rs.expected
@@ -35,15 +35,7 @@ impl ::pb_jelly::Message for NoPackage {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut field_size = 0;
-    if self.field != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.field;
-      let l = ::pb_jelly::Message::compute_size(val);
-      field_size += ::pb_jelly::wire_format::serialized_length(1);
-      field_size += ::pb_jelly::varint::serialized_length(l as u64);
-      field_size += l;
-    }
-    size += field_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.field, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
@@ -77,11 +77,7 @@ impl ::pb_jelly::Message for BytesData {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "BytesData", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::pb_jelly::Lazy<::bytes::Bytes> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::pb_jelly::Lazy<::bytes::Bytes>>(buf, typ, "BytesData", 1)?;
           self.data = Some(val);
         }
         _ => {
@@ -193,11 +189,7 @@ impl ::pb_jelly::Message for VecData {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "VecData", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "VecData", 1)?;
           self.data = Some(val);
         }
         _ => {
@@ -308,11 +300,7 @@ impl ::pb_jelly::Message for StringMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "StringMessage", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "StringMessage", 1)?;
           self.data = Some(val);
         }
         _ => {
@@ -423,11 +411,7 @@ impl ::pb_jelly::Message for StringMessageSSO {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "StringMessageSSO", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "StringMessageSSO", 1)?;
           self.data = Some(val);
         }
         _ => {
@@ -538,11 +522,7 @@ impl ::pb_jelly::Message for Cities {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Cities", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: City = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, City>(buf, typ, "Cities", 1)?;
           self.cities.push(val);
         }
         _ => {
@@ -881,55 +861,31 @@ impl ::pb_jelly::Message for City {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "City", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "City", 1)?;
           self.city = Some(val);
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "City", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "City", 2)?;
           self.growth_from_2000_to_2013 = Some(val);
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "City", 3)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "City", 3)?;
           self.latitude = Some(val);
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "City", 4)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "City", 4)?;
           self.longitude = Some(val);
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "City", 5)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "City", 5)?;
           self.population = Some(val);
         }
         6 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "City", 6)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "City", 6)?;
           self.rank = Some(val);
         }
         7 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "City", 7)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "City", 7)?;
           self.state = Some(val);
         }
         _ => {
@@ -1058,11 +1014,7 @@ impl ::pb_jelly::Message for CitiesSSO {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "CitiesSSO", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: CitySSO = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, CitySSO>(buf, typ, "CitiesSSO", 1)?;
           self.cities.push(val);
         }
         _ => {
@@ -1401,55 +1353,31 @@ impl ::pb_jelly::Message for CitySSO {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "CitySSO", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "CitySSO", 1)?;
           self.city = Some(val);
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "CitySSO", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "CitySSO", 2)?;
           self.growth_from_2000_to_2013 = Some(val);
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "CitySSO", 3)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "CitySSO", 3)?;
           self.latitude = Some(val);
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "CitySSO", 4)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "CitySSO", 4)?;
           self.longitude = Some(val);
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "CitySSO", 5)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "CitySSO", 5)?;
           self.population = Some(val);
         }
         6 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "CitySSO", 6)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "CitySSO", 6)?;
           self.rank = Some(val);
         }
         7 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "CitySSO", 7)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "CitySSO", 7)?;
           self.state = Some(val);
         }
         _ => {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
@@ -48,7 +48,7 @@ impl ::pb_jelly::Message for BytesData {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut data_size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       let l = ::pb_jelly::Message::compute_size(val);
       data_size += ::pb_jelly::wire_format::serialized_length(1);
       data_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -59,13 +59,13 @@ impl ::pb_jelly::Message for BytesData {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -160,7 +160,7 @@ impl ::pb_jelly::Message for VecData {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut data_size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       let l = ::pb_jelly::Message::compute_size(val);
       data_size += ::pb_jelly::wire_format::serialized_length(1);
       data_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -171,13 +171,13 @@ impl ::pb_jelly::Message for VecData {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -271,7 +271,7 @@ impl ::pb_jelly::Message for StringMessage {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut data_size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       let l = ::pb_jelly::Message::compute_size(val);
       data_size += ::pb_jelly::wire_format::serialized_length(1);
       data_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -282,13 +282,13 @@ impl ::pb_jelly::Message for StringMessage {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -382,7 +382,7 @@ impl ::pb_jelly::Message for StringMessageSSO {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut data_size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       let l = ::pb_jelly::Message::compute_size(val);
       data_size += ::pb_jelly::wire_format::serialized_length(1);
       data_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -393,13 +393,13 @@ impl ::pb_jelly::Message for StringMessageSSO {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.data {
+    if let Some(ref val) = self.data {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -736,7 +736,7 @@ impl ::pb_jelly::Message for City {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut city_size = 0;
-    for val in &self.city {
+    if let Some(ref val) = self.city {
       let l = ::pb_jelly::Message::compute_size(val);
       city_size += ::pb_jelly::wire_format::serialized_length(1);
       city_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -744,7 +744,7 @@ impl ::pb_jelly::Message for City {
     }
     size += city_size;
     let mut growth_from_2000_to_2013_size = 0;
-    for val in &self.growth_from_2000_to_2013 {
+    if let Some(ref val) = self.growth_from_2000_to_2013 {
       let l = ::pb_jelly::Message::compute_size(val);
       growth_from_2000_to_2013_size += ::pb_jelly::wire_format::serialized_length(2);
       growth_from_2000_to_2013_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -752,21 +752,21 @@ impl ::pb_jelly::Message for City {
     }
     size += growth_from_2000_to_2013_size;
     let mut latitude_size = 0;
-    for val in &self.latitude {
+    if let Some(ref val) = self.latitude {
       let l = ::pb_jelly::Message::compute_size(val);
       latitude_size += ::pb_jelly::wire_format::serialized_length(3);
       latitude_size += l;
     }
     size += latitude_size;
     let mut longitude_size = 0;
-    for val in &self.longitude {
+    if let Some(ref val) = self.longitude {
       let l = ::pb_jelly::Message::compute_size(val);
       longitude_size += ::pb_jelly::wire_format::serialized_length(4);
       longitude_size += l;
     }
     size += longitude_size;
     let mut population_size = 0;
-    for val in &self.population {
+    if let Some(ref val) = self.population {
       let l = ::pb_jelly::Message::compute_size(val);
       population_size += ::pb_jelly::wire_format::serialized_length(5);
       population_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -774,7 +774,7 @@ impl ::pb_jelly::Message for City {
     }
     size += population_size;
     let mut rank_size = 0;
-    for val in &self.rank {
+    if let Some(ref val) = self.rank {
       let l = ::pb_jelly::Message::compute_size(val);
       rank_size += ::pb_jelly::wire_format::serialized_length(6);
       rank_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -782,7 +782,7 @@ impl ::pb_jelly::Message for City {
     }
     size += rank_size;
     let mut state_size = 0;
-    for val in &self.state {
+    if let Some(ref val) = self.state {
       let l = ::pb_jelly::Message::compute_size(val);
       state_size += ::pb_jelly::wire_format::serialized_length(7);
       state_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -793,63 +793,63 @@ impl ::pb_jelly::Message for City {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.city {
+    if let Some(ref val) = self.city {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.growth_from_2000_to_2013 {
+    if let Some(ref val) = self.growth_from_2000_to_2013 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.latitude {
+    if let Some(ref val) = self.latitude {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.longitude {
+    if let Some(ref val) = self.longitude {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.population {
+    if let Some(ref val) = self.population {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.rank {
+    if let Some(ref val) = self.rank {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.state {
+    if let Some(ref val) = self.state {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.city {
+    if let Some(ref val) = self.city {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.growth_from_2000_to_2013 {
+    if let Some(ref val) = self.growth_from_2000_to_2013 {
       ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.latitude {
+    if let Some(ref val) = self.latitude {
       ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.longitude {
+    if let Some(ref val) = self.longitude {
       ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.population {
+    if let Some(ref val) = self.population {
       ::pb_jelly::wire_format::write(5, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.rank {
+    if let Some(ref val) = self.rank {
       ::pb_jelly::wire_format::write(6, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.state {
+    if let Some(ref val) = self.state {
       ::pb_jelly::wire_format::write(7, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -1228,7 +1228,7 @@ impl ::pb_jelly::Message for CitySSO {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut city_size = 0;
-    for val in &self.city {
+    if let Some(ref val) = self.city {
       let l = ::pb_jelly::Message::compute_size(val);
       city_size += ::pb_jelly::wire_format::serialized_length(1);
       city_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -1236,7 +1236,7 @@ impl ::pb_jelly::Message for CitySSO {
     }
     size += city_size;
     let mut growth_from_2000_to_2013_size = 0;
-    for val in &self.growth_from_2000_to_2013 {
+    if let Some(ref val) = self.growth_from_2000_to_2013 {
       let l = ::pb_jelly::Message::compute_size(val);
       growth_from_2000_to_2013_size += ::pb_jelly::wire_format::serialized_length(2);
       growth_from_2000_to_2013_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -1244,21 +1244,21 @@ impl ::pb_jelly::Message for CitySSO {
     }
     size += growth_from_2000_to_2013_size;
     let mut latitude_size = 0;
-    for val in &self.latitude {
+    if let Some(ref val) = self.latitude {
       let l = ::pb_jelly::Message::compute_size(val);
       latitude_size += ::pb_jelly::wire_format::serialized_length(3);
       latitude_size += l;
     }
     size += latitude_size;
     let mut longitude_size = 0;
-    for val in &self.longitude {
+    if let Some(ref val) = self.longitude {
       let l = ::pb_jelly::Message::compute_size(val);
       longitude_size += ::pb_jelly::wire_format::serialized_length(4);
       longitude_size += l;
     }
     size += longitude_size;
     let mut population_size = 0;
-    for val in &self.population {
+    if let Some(ref val) = self.population {
       let l = ::pb_jelly::Message::compute_size(val);
       population_size += ::pb_jelly::wire_format::serialized_length(5);
       population_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -1266,7 +1266,7 @@ impl ::pb_jelly::Message for CitySSO {
     }
     size += population_size;
     let mut rank_size = 0;
-    for val in &self.rank {
+    if let Some(ref val) = self.rank {
       let l = ::pb_jelly::Message::compute_size(val);
       rank_size += ::pb_jelly::wire_format::serialized_length(6);
       rank_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -1274,7 +1274,7 @@ impl ::pb_jelly::Message for CitySSO {
     }
     size += rank_size;
     let mut state_size = 0;
-    for val in &self.state {
+    if let Some(ref val) = self.state {
       let l = ::pb_jelly::Message::compute_size(val);
       state_size += ::pb_jelly::wire_format::serialized_length(7);
       state_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -1285,63 +1285,63 @@ impl ::pb_jelly::Message for CitySSO {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.city {
+    if let Some(ref val) = self.city {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.growth_from_2000_to_2013 {
+    if let Some(ref val) = self.growth_from_2000_to_2013 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.latitude {
+    if let Some(ref val) = self.latitude {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.longitude {
+    if let Some(ref val) = self.longitude {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.population {
+    if let Some(ref val) = self.population {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.rank {
+    if let Some(ref val) = self.rank {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.state {
+    if let Some(ref val) = self.state {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.city {
+    if let Some(ref val) = self.city {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.growth_from_2000_to_2013 {
+    if let Some(ref val) = self.growth_from_2000_to_2013 {
       ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.latitude {
+    if let Some(ref val) = self.latitude {
       ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.longitude {
+    if let Some(ref val) = self.longitude {
       ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.population {
+    if let Some(ref val) = self.population {
       ::pb_jelly::wire_format::write(5, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.rank {
+    if let Some(ref val) = self.rank {
       ::pb_jelly::wire_format::write(6, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.state {
+    if let Some(ref val) = self.state {
       ::pb_jelly::wire_format::write(7, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/bench.rs.expected
@@ -169,13 +169,6 @@ impl ::pb_jelly::Message for VecData {
     size += data_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.data {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.data {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -278,13 +271,6 @@ impl ::pb_jelly::Message for StringMessage {
       data_size += l;
     }
     size += data_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.data {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -391,13 +377,6 @@ impl ::pb_jelly::Message for StringMessageSSO {
     size += data_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.data {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.data {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -500,13 +479,6 @@ impl ::pb_jelly::Message for Cities {
       cities_size += l;
     }
     size += cities_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.cities {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -791,31 +763,6 @@ impl ::pb_jelly::Message for City {
     size += state_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.city {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.growth_from_2000_to_2013 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.latitude {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.longitude {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.population {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.rank {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.state {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.city {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -992,13 +939,6 @@ impl ::pb_jelly::Message for CitiesSSO {
       cities_size += l;
     }
     size += cities_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.cities {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1281,31 +1221,6 @@ impl ::pb_jelly::Message for CitySSO {
       state_size += l;
     }
     size += state_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.city {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.growth_from_2000_to_2013 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.latitude {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.longitude {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.population {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.rank {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.state {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/mod/struct.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/mod/struct.rs.expected
@@ -25,9 +25,6 @@ impl ::pb_jelly::Message for Message {
   fn compute_size(&self) -> usize {
     0
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    0
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     Ok(())
   }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -10,14 +10,6 @@ impl ForeignEnum {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<ForeignEnum_Closed> {
-    match self {
-      ForeignEnum::FOREIGN_FOO => Some(ForeignEnum_Closed::FOREIGN_FOO),
-      ForeignEnum::FOREIGN_BAR => Some(ForeignEnum_Closed::FOREIGN_BAR),
-      ForeignEnum::FOREIGN_BAZ => Some(ForeignEnum_Closed::FOREIGN_BAZ),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for ForeignEnum {
   fn default() -> Self {
@@ -42,27 +34,19 @@ impl From<ForeignEnum_Closed> for ForeignEnum {
 impl ::pb_jelly::ProtoEnum for ForeignEnum {
 }
 impl ::pb_jelly::OpenProtoEnum for ForeignEnum {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = ForeignEnum_Closed;
+  fn into_known(self) -> ::std::option::Option<ForeignEnum_Closed> {
     match self {
-      ForeignEnum::FOREIGN_FOO => Some("FOREIGN_FOO"),
-      ForeignEnum::FOREIGN_BAR => Some("FOREIGN_BAR"),
-      ForeignEnum::FOREIGN_BAZ => Some("FOREIGN_BAZ"),
+      ForeignEnum::FOREIGN_FOO => Some(ForeignEnum_Closed::FOREIGN_FOO),
+      ForeignEnum::FOREIGN_BAR => Some(ForeignEnum_Closed::FOREIGN_BAR),
+      ForeignEnum::FOREIGN_BAZ => Some(ForeignEnum_Closed::FOREIGN_BAZ),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      ForeignEnum::FOREIGN_FOO => true,
-      ForeignEnum::FOREIGN_BAR => true,
-      ForeignEnum::FOREIGN_BAZ => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for ForeignEnum {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }
@@ -124,12 +108,6 @@ impl Version1Enum_TestEnum {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<Version1Enum_TestEnum_Closed> {
-    match self {
-      Version1Enum_TestEnum::ENUM0 => Some(Version1Enum_TestEnum_Closed::ENUM0),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for Version1Enum_TestEnum {
   fn default() -> Self {
@@ -154,23 +132,17 @@ impl From<Version1Enum_TestEnum_Closed> for Version1Enum_TestEnum {
 impl ::pb_jelly::ProtoEnum for Version1Enum_TestEnum {
 }
 impl ::pb_jelly::OpenProtoEnum for Version1Enum_TestEnum {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = Version1Enum_TestEnum_Closed;
+  fn into_known(self) -> ::std::option::Option<Version1Enum_TestEnum_Closed> {
     match self {
-      Version1Enum_TestEnum::ENUM0 => Some("ENUM0"),
+      Version1Enum_TestEnum::ENUM0 => Some(Version1Enum_TestEnum_Closed::ENUM0),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      Version1Enum_TestEnum::ENUM0 => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for Version1Enum_TestEnum {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }
@@ -225,13 +197,6 @@ impl Version2Enum_TestEnum {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<Version2Enum_TestEnum_Closed> {
-    match self {
-      Version2Enum_TestEnum::ENUM0 => Some(Version2Enum_TestEnum_Closed::ENUM0),
-      Version2Enum_TestEnum::ENUM1 => Some(Version2Enum_TestEnum_Closed::ENUM1),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for Version2Enum_TestEnum {
   fn default() -> Self {
@@ -256,25 +221,18 @@ impl From<Version2Enum_TestEnum_Closed> for Version2Enum_TestEnum {
 impl ::pb_jelly::ProtoEnum for Version2Enum_TestEnum {
 }
 impl ::pb_jelly::OpenProtoEnum for Version2Enum_TestEnum {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = Version2Enum_TestEnum_Closed;
+  fn into_known(self) -> ::std::option::Option<Version2Enum_TestEnum_Closed> {
     match self {
-      Version2Enum_TestEnum::ENUM0 => Some("ENUM0"),
-      Version2Enum_TestEnum::ENUM1 => Some("ENUM1"),
+      Version2Enum_TestEnum::ENUM0 => Some(Version2Enum_TestEnum_Closed::ENUM0),
+      Version2Enum_TestEnum::ENUM1 => Some(Version2Enum_TestEnum_Closed::ENUM1),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      Version2Enum_TestEnum::ENUM0 => true,
-      Version2Enum_TestEnum::ENUM1 => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for Version2Enum_TestEnum {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }
@@ -336,15 +294,6 @@ impl TestMessage_NestedEnum {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<TestMessage_NestedEnum_Closed> {
-    match self {
-      TestMessage_NestedEnum::FOO => Some(TestMessage_NestedEnum_Closed::FOO),
-      TestMessage_NestedEnum::BAR => Some(TestMessage_NestedEnum_Closed::BAR),
-      TestMessage_NestedEnum::BAZ => Some(TestMessage_NestedEnum_Closed::BAZ),
-      TestMessage_NestedEnum::NEG => Some(TestMessage_NestedEnum_Closed::NEG),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for TestMessage_NestedEnum {
   fn default() -> Self {
@@ -369,29 +318,20 @@ impl From<TestMessage_NestedEnum_Closed> for TestMessage_NestedEnum {
 impl ::pb_jelly::ProtoEnum for TestMessage_NestedEnum {
 }
 impl ::pb_jelly::OpenProtoEnum for TestMessage_NestedEnum {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = TestMessage_NestedEnum_Closed;
+  fn into_known(self) -> ::std::option::Option<TestMessage_NestedEnum_Closed> {
     match self {
-      TestMessage_NestedEnum::FOO => Some("FOO"),
-      TestMessage_NestedEnum::BAR => Some("BAR"),
-      TestMessage_NestedEnum::BAZ => Some("BAZ"),
-      TestMessage_NestedEnum::NEG => Some("NEG"),
+      TestMessage_NestedEnum::FOO => Some(TestMessage_NestedEnum_Closed::FOO),
+      TestMessage_NestedEnum::BAR => Some(TestMessage_NestedEnum_Closed::BAR),
+      TestMessage_NestedEnum::BAZ => Some(TestMessage_NestedEnum_Closed::BAZ),
+      TestMessage_NestedEnum::NEG => Some(TestMessage_NestedEnum_Closed::NEG),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      TestMessage_NestedEnum::FOO => true,
-      TestMessage_NestedEnum::BAR => true,
-      TestMessage_NestedEnum::BAZ => true,
-      TestMessage_NestedEnum::NEG => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for TestMessage_NestedEnum {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -418,9 +418,6 @@ impl ::pb_jelly::Message for Option {
   fn compute_size(&self) -> usize {
     0
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    0
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     Ok(())
   }
@@ -478,9 +475,6 @@ impl ::pb_jelly::Message for Vec {
     })
   }
   fn compute_size(&self) -> usize {
-    0
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
     0
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -542,9 +536,6 @@ impl ::pb_jelly::Message for Default {
   fn compute_size(&self) -> usize {
     0
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    0
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     Ok(())
   }
@@ -602,9 +593,6 @@ impl ::pb_jelly::Message for String {
     })
   }
   fn compute_size(&self) -> usize {
-    0
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
     0
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -691,13 +679,6 @@ impl ::pb_jelly::Message for Version0OneOfNoneNullable {
       string_one_of_size += l;
     }
     size += string_one_of_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Version0OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -829,16 +810,6 @@ impl ::pb_jelly::Message for Version1OneOfNoneNullable {
       string_two_of_size += l;
     }
     size += string_two_of_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Version1OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Version1OneOfNoneNullable_TestOneof::StringTwoOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1020,19 +991,6 @@ impl ::pb_jelly::Message for Version2OneOfNoneNullable {
     size += int_one_Of_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Version2OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Version2OneOfNoneNullable_TestOneof::StringTwoOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Version2OneOfNoneNullable_TestOneof::IntOneOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Version2OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -1201,13 +1159,6 @@ impl ::pb_jelly::Message for Version1Enum {
     size += enum_field_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.enum_field {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.enum_field {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
@@ -1306,13 +1257,6 @@ impl ::pb_jelly::Message for Version2Enum {
     size += enum_field_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.enum_field {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.enum_field {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
@@ -1408,13 +1352,6 @@ impl ::pb_jelly::Message for Version1OneOf {
       string_one_of_size += l;
     }
     size += string_one_of_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(Version1OneOf_TestOneof::StringOneOf(ref val)) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1546,16 +1483,6 @@ impl ::pb_jelly::Message for Version2OneOf {
       int_one_of_size += l;
     }
     size += int_one_of_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(Version2OneOf_TestOneof::StringOneOf(ref val)) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(Version2OneOf_TestOneof::IntOneOf(ref val)) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1698,13 +1625,6 @@ impl ::pb_jelly::Message for Version1 {
       required_string_size += l;
     }
     size += required_string_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.required_string {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -2170,52 +2090,6 @@ impl ::pb_jelly::Message for Version2 {
     size += optional_float_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.required_string {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_int32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_int64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_uint32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_uint64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_fixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_fixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_sfixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_sfixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_double {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_bool {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_string {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_bytes {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_float {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.required_string {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -2461,13 +2335,6 @@ impl ::pb_jelly::Message for ForeignMessage {
       c_size += l;
     }
     size += c_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.c {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -3908,170 +3775,6 @@ impl ::pb_jelly::Message for TestMessage {
       unsafe_size += l;
     }
     size += unsafe_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.optional_int32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_int64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_uint32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_uint64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_fixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_fixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_sfixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_sfixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_double {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_bool {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_string {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_bytes {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_float {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_foreign_message {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_nested_enum {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_foreign_enum {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_int32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_int64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_uint32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_uint64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_fixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_fixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_sfixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_sfixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_double {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_bool {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_string {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_bytes {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_float {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_foreign_message {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_nested_enum {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_foreign_enum {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_foreign_message_boxed {
-      let val = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-     {
-      let val = &self.optional_foreign_message_nonnullable;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofInt::Int1(ref val)) = self.oneof_int {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofInt::Foreign1(ref val)) = self.oneof_int {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofForeign::Int2(ref val)) = self.oneof_foreign {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofForeign::Foreign2(ref val)) = self.oneof_foreign {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofZero::Int3(ref val)) = self.oneof_zero {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofZero::Foreign3(ref val)) = self.oneof_zero {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofNull::Int4(ref val)) = self.oneof_null {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofNull::Foreign4(ref val)) = self.oneof_null {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofUnset::Int5(ref val)) = self.oneof_unset {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofUnset::Foreign5(ref val)) = self.oneof_unset {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofPrimitives::Int6(ref val)) = self.oneof_primitives {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_OneofPrimitives::Bool6(ref val)) = self.oneof_primitives {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage_OneofEmptyField::A = self.oneof_empty_field {
-      let val: &::proto_google::protobuf::empty::Empty = &::std::default::Default::default();
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage_OneofEmptyField::B = self.oneof_empty_field {
-      let val: &::proto_google::protobuf::empty::Empty = &::std::default::Default::default();
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage_OneofEmptyField::C(ref val) = self.oneof_empty_field {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.r#type {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_Mod::Loop(ref val)) = self.r#mod {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage_Mod::Unsafe(ref val)) = self.r#mod {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -774,11 +774,7 @@ impl ::pb_jelly::Message for Version0OneOfNoneNullable {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version0OneOfNoneNullable", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version0OneOfNoneNullable", 1)?;
           oneof_test_oneof = Some(Version0OneOfNoneNullable_TestOneof::StringOneOf(val));
         }
         _ => {
@@ -925,19 +921,11 @@ impl ::pb_jelly::Message for Version1OneOfNoneNullable {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version1OneOfNoneNullable", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version1OneOfNoneNullable", 1)?;
           oneof_test_oneof = Some(Version1OneOfNoneNullable_TestOneof::StringOneOf(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version1OneOfNoneNullable", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version1OneOfNoneNullable", 2)?;
           oneof_test_oneof = Some(Version1OneOfNoneNullable_TestOneof::StringTwoOf(val));
         }
         _ => {
@@ -1129,25 +1117,15 @@ impl ::pb_jelly::Message for Version2OneOfNoneNullable {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version2OneOfNoneNullable", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version2OneOfNoneNullable", 1)?;
           oneof_test_oneof = Some(Version2OneOfNoneNullable_TestOneof::StringOneOf(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version2OneOfNoneNullable", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version2OneOfNoneNullable", 2)?;
           oneof_test_oneof = Some(Version2OneOfNoneNullable_TestOneof::StringTwoOf(val));
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2OneOfNoneNullable", 3)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2OneOfNoneNullable", 3)?;
           oneof_test_oneof = Some(Version2OneOfNoneNullable_TestOneof::IntOneOf(val));
         }
         _ => {
@@ -1301,9 +1279,7 @@ impl ::pb_jelly::Message for Version1Enum {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version1Enum", 1)?;
-          let mut val: Version1Enum_TestEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, Version1Enum_TestEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version1Enum", 1)?;
           self.enum_field = Some(val);
         }
         _ => {
@@ -1408,9 +1384,7 @@ impl ::pb_jelly::Message for Version2Enum {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2Enum", 1)?;
-          let mut val: Version2Enum_TestEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, Version2Enum_TestEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2Enum", 1)?;
           self.enum_field = Some(val);
         }
         _ => {
@@ -1516,11 +1490,7 @@ impl ::pb_jelly::Message for Version1OneOf {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version1OneOf", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version1OneOf", 1)?;
           self.test_oneof = Some(Version1OneOf_TestOneof::StringOneOf(val));
         }
         _ => {
@@ -1665,17 +1635,11 @@ impl ::pb_jelly::Message for Version2OneOf {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version2OneOf", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version2OneOf", 1)?;
           self.test_oneof = Some(Version2OneOf_TestOneof::StringOneOf(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2OneOf", 2)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2OneOf", 2)?;
           self.test_oneof = Some(Version2OneOf_TestOneof::IntOneOf(val));
         }
         _ => {
@@ -1816,11 +1780,7 @@ impl ::pb_jelly::Message for Version1 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version1", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version1", 1)?;
           self.required_string = Some(val);
         }
         _ => {
@@ -2385,93 +2345,59 @@ impl ::pb_jelly::Message for Version2 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version2", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version2", 1)?;
           self.required_string = Some(val);
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 2)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 2)?;
           self.optional_int32 = Some(val);
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 3)?;
-          let mut val: i64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 3)?;
           self.optional_int64 = Some(val);
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 4)?;
-          let mut val: u32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 4)?;
           self.optional_uint32 = Some(val);
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 5)?;
-          let mut val: u64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 5)?;
           self.optional_uint64 = Some(val);
         }
         6 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "Version2", 6)?;
-          let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "Version2", 6)?;
           self.optional_fixed64 = Some(val);
         }
         7 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "Version2", 7)?;
-          let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "Version2", 7)?;
           self.optional_fixed32 = Some(val);
         }
         8 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "Version2", 8)?;
-          let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "Version2", 8)?;
           self.optional_sfixed64 = Some(val);
         }
         9 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "Version2", 9)?;
-          let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "Version2", 9)?;
           self.optional_sfixed32 = Some(val);
         }
         10 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "Version2", 10)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "Version2", 10)?;
           self.optional_double = Some(val);
         }
         11 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 11)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version2", 11)?;
           self.optional_bool = Some(val);
         }
         12 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version2", 12)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version2", 12)?;
           self.optional_string = Some(val);
         }
         13 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version2", 13)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "Version2", 13)?;
           self.optional_bytes = Some(val);
         }
         14 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "Version2", 14)?;
-          let mut val: f32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "Version2", 14)?;
           self.optional_float = Some(val);
         }
         _ => {
@@ -2615,9 +2541,7 @@ impl ::pb_jelly::Message for ForeignMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "ForeignMessage", 1)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "ForeignMessage", 1)?;
           self.c = Some(val);
         }
         _ => {
@@ -4460,514 +4384,198 @@ impl ::pb_jelly::Message for TestMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 1)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 1)?;
           self.optional_int32 = Some(val);
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 2)?;
-          let mut val: i64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 2)?;
           self.optional_int64 = Some(val);
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 3)?;
-          let mut val: u32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 3)?;
           self.optional_uint32 = Some(val);
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 4)?;
-          let mut val: u64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 4)?;
           self.optional_uint64 = Some(val);
         }
         8 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 8)?;
-          let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 8)?;
           self.optional_fixed64 = Some(val);
         }
         9 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 9)?;
-          let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 9)?;
           self.optional_fixed32 = Some(val);
         }
         10 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 10)?;
-          let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 10)?;
           self.optional_sfixed64 = Some(val);
         }
         11 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 11)?;
-          let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 11)?;
           self.optional_sfixed32 = Some(val);
         }
         12 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 12)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 12)?;
           self.optional_double = Some(val);
         }
         13 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 13)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 13)?;
           self.optional_bool = Some(val);
         }
         14 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 14)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestMessage", 14)?;
           self.optional_string = Some(val);
         }
         15 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 15)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "TestMessage", 15)?;
           self.optional_bytes = Some(val);
         }
         16 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 16)?;
-          let mut val: f32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 16)?;
           self.optional_float = Some(val);
         }
         19 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 19)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 19)?;
           self.optional_foreign_message = Some(val);
         }
         21 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 21)?;
-          let mut val: TestMessage_NestedEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage_NestedEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 21)?;
           self.optional_nested_enum = Some(val);
         }
         22 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 22)?;
-          let mut val: ForeignEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ForeignEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 22)?;
           self.optional_foreign_enum = Some(val);
         }
         31 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: i32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_int32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 31)?;
-              let mut val: i32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_int32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 31, &mut self.repeated_int32)?;
         }
         32 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: i64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_int64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 32)?;
-              let mut val: i64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_int64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 32, &mut self.repeated_int64)?;
         }
         33 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: u32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_uint32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 33)?;
-              let mut val: u32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_uint32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 33, &mut self.repeated_uint32)?;
         }
         34 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: u64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_uint64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 34)?;
-              let mut val: u64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_uint64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 34, &mut self.repeated_uint64)?;
         }
         38 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_fixed64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 38)?;
-              let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_fixed64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 38, &mut self.repeated_fixed64)?;
         }
         39 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_fixed32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 39)?;
-              let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_fixed32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 39, &mut self.repeated_fixed32)?;
         }
         40 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_sfixed64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 40)?;
-              let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_sfixed64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 40, &mut self.repeated_sfixed64)?;
         }
         41 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_sfixed32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 41)?;
-              let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_sfixed32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 41, &mut self.repeated_sfixed32)?;
         }
         42 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: f64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_double.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 42)?;
-              let mut val: f64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_double.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage", 42, &mut self.repeated_double)?;
         }
         43 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: bool = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_bool.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 43)?;
-              let mut val: bool = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_bool.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 43, &mut self.repeated_bool)?;
         }
         44 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 44)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestMessage", 44)?;
           self.repeated_string.push(val);
         }
         45 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 45)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "TestMessage", 45)?;
           self.repeated_bytes.push(val);
         }
         46 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: f32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_float.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 46)?;
-              let mut val: f32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_float.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage", 46, &mut self.repeated_float)?;
         }
         49 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 49)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 49)?;
           self.repeated_foreign_message.push(val);
         }
         51 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: TestMessage_NestedEnum = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_nested_enum.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 51)?;
-              let mut val: TestMessage_NestedEnum = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_nested_enum.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, TestMessage_NestedEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 51, &mut self.repeated_nested_enum)?;
         }
         52 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ForeignEnum = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_foreign_enum.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 52)?;
-              let mut val: ForeignEnum = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_foreign_enum.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ForeignEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 52, &mut self.repeated_foreign_enum)?;
         }
         53 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 53)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 53)?;
           self.optional_foreign_message_boxed = Some(Box::new(val));
         }
         54 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 54)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 54)?;
           self.optional_foreign_message_nonnullable = val;
         }
         57 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 57)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 57)?;
           self.oneof_int = Some(TestMessage_OneofInt::Int1(val));
         }
         58 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 58)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 58)?;
           self.oneof_int = Some(TestMessage_OneofInt::Foreign1(val));
         }
         59 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 59)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 59)?;
           self.oneof_foreign = Some(TestMessage_OneofForeign::Int2(val));
         }
         60 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 60)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 60)?;
           self.oneof_foreign = Some(TestMessage_OneofForeign::Foreign2(val));
         }
         61 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 61)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 61)?;
           self.oneof_zero = Some(TestMessage_OneofZero::Int3(val));
         }
         62 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 62)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 62)?;
           self.oneof_zero = Some(TestMessage_OneofZero::Foreign3(val));
         }
         63 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 63)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 63)?;
           self.oneof_null = Some(TestMessage_OneofNull::Int4(val));
         }
         64 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 64)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 64)?;
           self.oneof_null = Some(TestMessage_OneofNull::Foreign4(val));
         }
         65 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 65)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 65)?;
           self.oneof_unset = Some(TestMessage_OneofUnset::Int5(val));
         }
         66 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 66)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage>(buf, typ, "TestMessage", 66)?;
           self.oneof_unset = Some(TestMessage_OneofUnset::Foreign5(val));
         }
         67 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 67)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 67)?;
           self.oneof_primitives = Some(TestMessage_OneofPrimitives::Int6(val));
         }
         68 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 68)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 68)?;
           self.oneof_primitives = Some(TestMessage_OneofPrimitives::Bool6(val));
         }
         70 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 70)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::proto_google::protobuf::empty::Empty = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::proto_google::protobuf::empty::Empty>(buf, typ, "TestMessage", 70)?;
           oneof_oneof_empty_field = Some(TestMessage_OneofEmptyField::A);
         }
         71 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage", 71)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::proto_google::protobuf::empty::Empty = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::proto_google::protobuf::empty::Empty>(buf, typ, "TestMessage", 71)?;
           oneof_oneof_empty_field = Some(TestMessage_OneofEmptyField::B);
         }
         72 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 72)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 72)?;
           oneof_oneof_empty_field = Some(TestMessage_OneofEmptyField::C(val));
         }
         73 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 73)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 73)?;
           self.r#type = Some(val);
         }
         74 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 74)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 74)?;
           self.r#mod = Some(TestMessage_Mod::Loop(val));
         }
         75 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 75)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage", 75)?;
           self.r#mod = Some(TestMessage_Mod::Unsafe(val));
         }
         _ => {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest2.rs.expected
@@ -1193,7 +1193,7 @@ impl ::pb_jelly::Message for Version1Enum {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut enum_field_size = 0;
-    for val in &self.enum_field {
+    if let Some(ref val) = self.enum_field {
       let l = ::pb_jelly::Message::compute_size(val);
       enum_field_size += ::pb_jelly::wire_format::serialized_length(1);
       enum_field_size += l;
@@ -1203,13 +1203,13 @@ impl ::pb_jelly::Message for Version1Enum {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.enum_field {
+    if let Some(ref val) = self.enum_field {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.enum_field {
+    if let Some(ref val) = self.enum_field {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
@@ -1298,7 +1298,7 @@ impl ::pb_jelly::Message for Version2Enum {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut enum_field_size = 0;
-    for val in &self.enum_field {
+    if let Some(ref val) = self.enum_field {
       let l = ::pb_jelly::Message::compute_size(val);
       enum_field_size += ::pb_jelly::wire_format::serialized_length(1);
       enum_field_size += l;
@@ -1308,13 +1308,13 @@ impl ::pb_jelly::Message for Version2Enum {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.enum_field {
+    if let Some(ref val) = self.enum_field {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.enum_field {
+    if let Some(ref val) = self.enum_field {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
@@ -1691,7 +1691,7 @@ impl ::pb_jelly::Message for Version1 {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut required_string_size = 0;
-    for val in &self.required_string {
+    if let Some(ref val) = self.required_string {
       let l = ::pb_jelly::Message::compute_size(val);
       required_string_size += ::pb_jelly::wire_format::serialized_length(1);
       required_string_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -1702,13 +1702,13 @@ impl ::pb_jelly::Message for Version1 {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.required_string {
+    if let Some(ref val) = self.required_string {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.required_string {
+    if let Some(ref val) = self.required_string {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -2068,7 +2068,7 @@ impl ::pb_jelly::Message for Version2 {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut required_string_size = 0;
-    for val in &self.required_string {
+    if let Some(ref val) = self.required_string {
       let l = ::pb_jelly::Message::compute_size(val);
       required_string_size += ::pb_jelly::wire_format::serialized_length(1);
       required_string_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -2076,77 +2076,77 @@ impl ::pb_jelly::Message for Version2 {
     }
     size += required_string_size;
     let mut optional_int32_size = 0;
-    for val in &self.optional_int32 {
+    if let Some(ref val) = self.optional_int32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_int32_size += ::pb_jelly::wire_format::serialized_length(2);
       optional_int32_size += l;
     }
     size += optional_int32_size;
     let mut optional_int64_size = 0;
-    for val in &self.optional_int64 {
+    if let Some(ref val) = self.optional_int64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_int64_size += ::pb_jelly::wire_format::serialized_length(3);
       optional_int64_size += l;
     }
     size += optional_int64_size;
     let mut optional_uint32_size = 0;
-    for val in &self.optional_uint32 {
+    if let Some(ref val) = self.optional_uint32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_uint32_size += ::pb_jelly::wire_format::serialized_length(4);
       optional_uint32_size += l;
     }
     size += optional_uint32_size;
     let mut optional_uint64_size = 0;
-    for val in &self.optional_uint64 {
+    if let Some(ref val) = self.optional_uint64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_uint64_size += ::pb_jelly::wire_format::serialized_length(5);
       optional_uint64_size += l;
     }
     size += optional_uint64_size;
     let mut optional_fixed64_size = 0;
-    for val in &self.optional_fixed64 {
+    if let Some(ref val) = self.optional_fixed64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_fixed64_size += ::pb_jelly::wire_format::serialized_length(6);
       optional_fixed64_size += l;
     }
     size += optional_fixed64_size;
     let mut optional_fixed32_size = 0;
-    for val in &self.optional_fixed32 {
+    if let Some(ref val) = self.optional_fixed32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_fixed32_size += ::pb_jelly::wire_format::serialized_length(7);
       optional_fixed32_size += l;
     }
     size += optional_fixed32_size;
     let mut optional_sfixed64_size = 0;
-    for val in &self.optional_sfixed64 {
+    if let Some(ref val) = self.optional_sfixed64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_sfixed64_size += ::pb_jelly::wire_format::serialized_length(8);
       optional_sfixed64_size += l;
     }
     size += optional_sfixed64_size;
     let mut optional_sfixed32_size = 0;
-    for val in &self.optional_sfixed32 {
+    if let Some(ref val) = self.optional_sfixed32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_sfixed32_size += ::pb_jelly::wire_format::serialized_length(9);
       optional_sfixed32_size += l;
     }
     size += optional_sfixed32_size;
     let mut optional_double_size = 0;
-    for val in &self.optional_double {
+    if let Some(ref val) = self.optional_double {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_double_size += ::pb_jelly::wire_format::serialized_length(10);
       optional_double_size += l;
     }
     size += optional_double_size;
     let mut optional_bool_size = 0;
-    for val in &self.optional_bool {
+    if let Some(ref val) = self.optional_bool {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_bool_size += ::pb_jelly::wire_format::serialized_length(11);
       optional_bool_size += l;
     }
     size += optional_bool_size;
     let mut optional_string_size = 0;
-    for val in &self.optional_string {
+    if let Some(ref val) = self.optional_string {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_string_size += ::pb_jelly::wire_format::serialized_length(12);
       optional_string_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -2154,7 +2154,7 @@ impl ::pb_jelly::Message for Version2 {
     }
     size += optional_string_size;
     let mut optional_bytes_size = 0;
-    for val in &self.optional_bytes {
+    if let Some(ref val) = self.optional_bytes {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_bytes_size += ::pb_jelly::wire_format::serialized_length(13);
       optional_bytes_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -2162,7 +2162,7 @@ impl ::pb_jelly::Message for Version2 {
     }
     size += optional_bytes_size;
     let mut optional_float_size = 0;
-    for val in &self.optional_float {
+    if let Some(ref val) = self.optional_float {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_float_size += ::pb_jelly::wire_format::serialized_length(14);
       optional_float_size += l;
@@ -2172,110 +2172,110 @@ impl ::pb_jelly::Message for Version2 {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.required_string {
+    if let Some(ref val) = self.required_string {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_int32 {
+    if let Some(ref val) = self.optional_int32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_int64 {
+    if let Some(ref val) = self.optional_int64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_uint32 {
+    if let Some(ref val) = self.optional_uint32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_uint64 {
+    if let Some(ref val) = self.optional_uint64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_fixed64 {
+    if let Some(ref val) = self.optional_fixed64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_fixed32 {
+    if let Some(ref val) = self.optional_fixed32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_sfixed64 {
+    if let Some(ref val) = self.optional_sfixed64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_sfixed32 {
+    if let Some(ref val) = self.optional_sfixed32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_double {
+    if let Some(ref val) = self.optional_double {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_bool {
+    if let Some(ref val) = self.optional_bool {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_string {
+    if let Some(ref val) = self.optional_string {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_bytes {
+    if let Some(ref val) = self.optional_bytes {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_float {
+    if let Some(ref val) = self.optional_float {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.required_string {
+    if let Some(ref val) = self.required_string {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_int32 {
+    if let Some(ref val) = self.optional_int32 {
       ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_int64 {
+    if let Some(ref val) = self.optional_int64 {
       ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_uint32 {
+    if let Some(ref val) = self.optional_uint32 {
       ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_uint64 {
+    if let Some(ref val) = self.optional_uint64 {
       ::pb_jelly::wire_format::write(5, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_fixed64 {
+    if let Some(ref val) = self.optional_fixed64 {
       ::pb_jelly::wire_format::write(6, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_fixed32 {
+    if let Some(ref val) = self.optional_fixed32 {
       ::pb_jelly::wire_format::write(7, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_sfixed64 {
+    if let Some(ref val) = self.optional_sfixed64 {
       ::pb_jelly::wire_format::write(8, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_sfixed32 {
+    if let Some(ref val) = self.optional_sfixed32 {
       ::pb_jelly::wire_format::write(9, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_double {
+    if let Some(ref val) = self.optional_double {
       ::pb_jelly::wire_format::write(10, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_bool {
+    if let Some(ref val) = self.optional_bool {
       ::pb_jelly::wire_format::write(11, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_string {
+    if let Some(ref val) = self.optional_string {
       ::pb_jelly::wire_format::write(12, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_bytes {
+    if let Some(ref val) = self.optional_bytes {
       ::pb_jelly::wire_format::write(13, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_float {
+    if let Some(ref val) = self.optional_float {
       ::pb_jelly::wire_format::write(14, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
@@ -2455,7 +2455,7 @@ impl ::pb_jelly::Message for ForeignMessage {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut c_size = 0;
-    for val in &self.c {
+    if let Some(ref val) = self.c {
       let l = ::pb_jelly::Message::compute_size(val);
       c_size += ::pb_jelly::wire_format::serialized_length(1);
       c_size += l;
@@ -2465,13 +2465,13 @@ impl ::pb_jelly::Message for ForeignMessage {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.c {
+    if let Some(ref val) = self.c {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.c {
+    if let Some(ref val) = self.c {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
@@ -3526,77 +3526,77 @@ impl ::pb_jelly::Message for TestMessage {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut optional_int32_size = 0;
-    for val in &self.optional_int32 {
+    if let Some(ref val) = self.optional_int32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_int32_size += ::pb_jelly::wire_format::serialized_length(1);
       optional_int32_size += l;
     }
     size += optional_int32_size;
     let mut optional_int64_size = 0;
-    for val in &self.optional_int64 {
+    if let Some(ref val) = self.optional_int64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_int64_size += ::pb_jelly::wire_format::serialized_length(2);
       optional_int64_size += l;
     }
     size += optional_int64_size;
     let mut optional_uint32_size = 0;
-    for val in &self.optional_uint32 {
+    if let Some(ref val) = self.optional_uint32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_uint32_size += ::pb_jelly::wire_format::serialized_length(3);
       optional_uint32_size += l;
     }
     size += optional_uint32_size;
     let mut optional_uint64_size = 0;
-    for val in &self.optional_uint64 {
+    if let Some(ref val) = self.optional_uint64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_uint64_size += ::pb_jelly::wire_format::serialized_length(4);
       optional_uint64_size += l;
     }
     size += optional_uint64_size;
     let mut optional_fixed64_size = 0;
-    for val in &self.optional_fixed64 {
+    if let Some(ref val) = self.optional_fixed64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_fixed64_size += ::pb_jelly::wire_format::serialized_length(8);
       optional_fixed64_size += l;
     }
     size += optional_fixed64_size;
     let mut optional_fixed32_size = 0;
-    for val in &self.optional_fixed32 {
+    if let Some(ref val) = self.optional_fixed32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_fixed32_size += ::pb_jelly::wire_format::serialized_length(9);
       optional_fixed32_size += l;
     }
     size += optional_fixed32_size;
     let mut optional_sfixed64_size = 0;
-    for val in &self.optional_sfixed64 {
+    if let Some(ref val) = self.optional_sfixed64 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_sfixed64_size += ::pb_jelly::wire_format::serialized_length(10);
       optional_sfixed64_size += l;
     }
     size += optional_sfixed64_size;
     let mut optional_sfixed32_size = 0;
-    for val in &self.optional_sfixed32 {
+    if let Some(ref val) = self.optional_sfixed32 {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_sfixed32_size += ::pb_jelly::wire_format::serialized_length(11);
       optional_sfixed32_size += l;
     }
     size += optional_sfixed32_size;
     let mut optional_double_size = 0;
-    for val in &self.optional_double {
+    if let Some(ref val) = self.optional_double {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_double_size += ::pb_jelly::wire_format::serialized_length(12);
       optional_double_size += l;
     }
     size += optional_double_size;
     let mut optional_bool_size = 0;
-    for val in &self.optional_bool {
+    if let Some(ref val) = self.optional_bool {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_bool_size += ::pb_jelly::wire_format::serialized_length(13);
       optional_bool_size += l;
     }
     size += optional_bool_size;
     let mut optional_string_size = 0;
-    for val in &self.optional_string {
+    if let Some(ref val) = self.optional_string {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_string_size += ::pb_jelly::wire_format::serialized_length(14);
       optional_string_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3604,7 +3604,7 @@ impl ::pb_jelly::Message for TestMessage {
     }
     size += optional_string_size;
     let mut optional_bytes_size = 0;
-    for val in &self.optional_bytes {
+    if let Some(ref val) = self.optional_bytes {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_bytes_size += ::pb_jelly::wire_format::serialized_length(15);
       optional_bytes_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3612,14 +3612,14 @@ impl ::pb_jelly::Message for TestMessage {
     }
     size += optional_bytes_size;
     let mut optional_float_size = 0;
-    for val in &self.optional_float {
+    if let Some(ref val) = self.optional_float {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_float_size += ::pb_jelly::wire_format::serialized_length(16);
       optional_float_size += l;
     }
     size += optional_float_size;
     let mut optional_foreign_message_size = 0;
-    for val in &self.optional_foreign_message {
+    if let Some(ref val) = self.optional_foreign_message {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_foreign_message_size += ::pb_jelly::wire_format::serialized_length(19);
       optional_foreign_message_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3627,14 +3627,14 @@ impl ::pb_jelly::Message for TestMessage {
     }
     size += optional_foreign_message_size;
     let mut optional_nested_enum_size = 0;
-    for val in &self.optional_nested_enum {
+    if let Some(ref val) = self.optional_nested_enum {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_nested_enum_size += ::pb_jelly::wire_format::serialized_length(21);
       optional_nested_enum_size += l;
     }
     size += optional_nested_enum_size;
     let mut optional_foreign_enum_size = 0;
-    for val in &self.optional_foreign_enum {
+    if let Some(ref val) = self.optional_foreign_enum {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_foreign_enum_size += ::pb_jelly::wire_format::serialized_length(22);
       optional_foreign_enum_size += l;
@@ -3756,7 +3756,7 @@ impl ::pb_jelly::Message for TestMessage {
     }
     size += repeated_foreign_enum_size;
     let mut optional_foreign_message_boxed_size = 0;
-    for val in &self.optional_foreign_message_boxed {
+    if let Some(ref val) = self.optional_foreign_message_boxed {
       let val = &**val;
       let l = ::pb_jelly::Message::compute_size(val);
       optional_foreign_message_boxed_size += ::pb_jelly::wire_format::serialized_length(53);
@@ -3888,7 +3888,7 @@ impl ::pb_jelly::Message for TestMessage {
     }
     size += c_size;
     let mut type_size = 0;
-    for val in &self.r#type {
+    if let Some(ref val) = self.r#type {
       let l = ::pb_jelly::Message::compute_size(val);
       type_size += ::pb_jelly::wire_format::serialized_length(73);
       type_size += l;
@@ -3912,52 +3912,52 @@ impl ::pb_jelly::Message for TestMessage {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.optional_int32 {
+    if let Some(ref val) = self.optional_int32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_int64 {
+    if let Some(ref val) = self.optional_int64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_uint32 {
+    if let Some(ref val) = self.optional_uint32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_uint64 {
+    if let Some(ref val) = self.optional_uint64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_fixed64 {
+    if let Some(ref val) = self.optional_fixed64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_fixed32 {
+    if let Some(ref val) = self.optional_fixed32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_sfixed64 {
+    if let Some(ref val) = self.optional_sfixed64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_sfixed32 {
+    if let Some(ref val) = self.optional_sfixed32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_double {
+    if let Some(ref val) = self.optional_double {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_bool {
+    if let Some(ref val) = self.optional_bool {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_string {
+    if let Some(ref val) = self.optional_string {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_bytes {
+    if let Some(ref val) = self.optional_bytes {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_float {
+    if let Some(ref val) = self.optional_float {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_foreign_message {
+    if let Some(ref val) = self.optional_foreign_message {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_nested_enum {
+    if let Some(ref val) = self.optional_nested_enum {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_foreign_enum {
+    if let Some(ref val) = self.optional_foreign_enum {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     for val in &self.repeated_int32 {
@@ -4008,7 +4008,7 @@ impl ::pb_jelly::Message for TestMessage {
     for val in &self.repeated_foreign_enum {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_foreign_message_boxed {
+    if let Some(ref val) = self.optional_foreign_message_boxed {
       let val = &**val;
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
@@ -4063,7 +4063,7 @@ impl ::pb_jelly::Message for TestMessage {
     if let TestMessage_OneofEmptyField::C(ref val) = self.oneof_empty_field {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.r#type {
+    if let Some(ref val) = self.r#type {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     if let Some(TestMessage_Mod::Loop(ref val)) = self.r#mod {
@@ -4075,73 +4075,73 @@ impl ::pb_jelly::Message for TestMessage {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.optional_int32 {
+    if let Some(ref val) = self.optional_int32 {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_int64 {
+    if let Some(ref val) = self.optional_int64 {
       ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_uint32 {
+    if let Some(ref val) = self.optional_uint32 {
       ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_uint64 {
+    if let Some(ref val) = self.optional_uint64 {
       ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_fixed64 {
+    if let Some(ref val) = self.optional_fixed64 {
       ::pb_jelly::wire_format::write(8, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_fixed32 {
+    if let Some(ref val) = self.optional_fixed32 {
       ::pb_jelly::wire_format::write(9, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_sfixed64 {
+    if let Some(ref val) = self.optional_sfixed64 {
       ::pb_jelly::wire_format::write(10, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_sfixed32 {
+    if let Some(ref val) = self.optional_sfixed32 {
       ::pb_jelly::wire_format::write(11, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_double {
+    if let Some(ref val) = self.optional_double {
       ::pb_jelly::wire_format::write(12, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_bool {
+    if let Some(ref val) = self.optional_bool {
       ::pb_jelly::wire_format::write(13, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_string {
+    if let Some(ref val) = self.optional_string {
       ::pb_jelly::wire_format::write(14, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_bytes {
+    if let Some(ref val) = self.optional_bytes {
       ::pb_jelly::wire_format::write(15, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_float {
+    if let Some(ref val) = self.optional_float {
       ::pb_jelly::wire_format::write(16, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_foreign_message {
+    if let Some(ref val) = self.optional_foreign_message {
       ::pb_jelly::wire_format::write(19, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_nested_enum {
+    if let Some(ref val) = self.optional_nested_enum {
       ::pb_jelly::wire_format::write(21, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_foreign_enum {
+    if let Some(ref val) = self.optional_foreign_enum {
       ::pb_jelly::wire_format::write(22, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
@@ -4215,7 +4215,7 @@ impl ::pb_jelly::Message for TestMessage {
       ::pb_jelly::wire_format::write(52, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_foreign_message_boxed {
+    if let Some(ref val) = self.optional_foreign_message_boxed {
       let val = &**val;
       ::pb_jelly::wire_format::write(53, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
@@ -4305,7 +4305,7 @@ impl ::pb_jelly::Message for TestMessage {
       ::pb_jelly::wire_format::write(72, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.r#type {
+    if let Some(ref val) = self.r#type {
       ::pb_jelly::wire_format::write(73, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -723,14 +723,6 @@ impl ::pb_jelly::Message for ForeignMessage3 {
     size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.c, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.c != <i32 as ::std::default::Default>::default() {
-      let val = &self.c;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.c, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
@@ -839,16 +831,6 @@ impl ::pb_jelly::Message for Version31OneOfNoneNullable {
       string_two_of_size += l;
     }
     size += string_two_of_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Version31OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Version31OneOfNoneNullable_TestOneof::StringTwoOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1028,19 +1010,6 @@ impl ::pb_jelly::Message for Version32OneOfNoneNullable {
     size += int_one_Of_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Version32OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Version32OneOfNoneNullable_TestOneof::StringTwoOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Version32OneOfNoneNullable_TestOneof::IntOneOf(ref val) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Version32OneOfNoneNullable_TestOneof::StringOneOf(ref val) = self.test_oneof {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -1192,14 +1161,6 @@ impl ::pb_jelly::Message for Version31Enum {
     size += ::pb_jelly::helpers::compute_size_scalar::<Version31Enum_TestEnum>(&self.enum_field, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.enum_field != <Version31Enum_TestEnum as ::std::default::Default>::default() {
-      let val = &self.enum_field;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, Version31Enum_TestEnum>(w, &self.enum_field, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
@@ -1276,14 +1237,6 @@ impl ::pb_jelly::Message for Version32Enum {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<Version32Enum_TestEnum>(&self.enum_field, 1, ::pb_jelly::wire_format::Type::Varint);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.enum_field != <Version32Enum_TestEnum as ::std::default::Default>::default() {
-      let val = &self.enum_field;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1376,13 +1329,6 @@ impl ::pb_jelly::Message for Version31OneOf {
       string_one_of_size += l;
     }
     size += string_one_of_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(Version31OneOf_TestOneof::StringOneOf(ref val)) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1514,16 +1460,6 @@ impl ::pb_jelly::Message for Version32OneOf {
     size += int_one_of_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(Version32OneOf_TestOneof::StringOneOf(ref val)) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(Version32OneOf_TestOneof::IntOneOf(ref val)) = self.test_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(Version32OneOf_TestOneof::StringOneOf(ref val)) = self.test_oneof {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -1645,14 +1581,6 @@ impl ::pb_jelly::Message for Version31 {
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.optional_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
@@ -1729,14 +1657,6 @@ impl ::pb_jelly::Message for Version31SSO {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.optional_string1 != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -1971,66 +1891,6 @@ impl ::pb_jelly::Message for Version32 {
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.optional_string, 12, ::pb_jelly::wire_format::Type::LengthDelimited);
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::vec::Vec<u8>>(&self.optional_bytes, 13, ::pb_jelly::wire_format::Type::LengthDelimited);
     size += ::pb_jelly::helpers::compute_size_scalar::<f32>(&self.optional_float, 14, ::pb_jelly::wire_format::Type::Fixed32);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.optional_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.optional_int32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.optional_int64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.optional_uint32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.optional_uint64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.optional_double;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.optional_bool;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.optional_bytes;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.optional_float;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -3273,191 +3133,6 @@ impl ::pb_jelly::Message for TestMessage3 {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    if self.optional_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.optional_int32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.optional_int64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.optional_uint32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.optional_uint64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.optional_double;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.optional_bool;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.optional_bytes;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.optional_float;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_foreign_message {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_nested_enum != <TestMessage3_NestedEnum3 as ::std::default::Default>::default() {
-      let val = &self.optional_nested_enum;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.optional_foreign_enum != <ForeignEnum3 as ::std::default::Default>::default() {
-      let val = &self.optional_foreign_enum;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_int32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_int64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_uint32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_uint64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_fixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_fixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_sfixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_sfixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_double {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_bool {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_string {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_bytes {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_float {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_foreign_message {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_nested_enum {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.repeated_foreign_enum {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.proto2_msg {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.proto2_msg_empty {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.proto2_msg_missing {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.optional_foreign_message_boxed {
-      let val = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-     {
-      let val = &self.optional_foreign_message_nonnullable;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofInt::Int1(ref val)) = self.oneof_int {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofInt::Foreign1(ref val)) = self.oneof_int {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofForeign::Int2(ref val)) = self.oneof_foreign {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofForeign::Foreign2(ref val)) = self.oneof_foreign {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofZero::Int3(ref val)) = self.oneof_zero {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofZero::Foreign3(ref val)) = self.oneof_zero {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofNull::Int4(ref val)) = self.oneof_null {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofNull::Foreign4(ref val)) = self.oneof_null {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofUnset::Int5(ref val)) = self.oneof_unset {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofUnset::Foreign5(ref val)) = self.oneof_unset {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofPrimitives::Int6(ref val)) = self.oneof_primitives {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestMessage3_OneofPrimitives::Bool6(ref val)) = self.oneof_primitives {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage3_OneofEmptyField::A = self.oneof_empty_field {
-      let val: &::proto_google::protobuf::empty::Empty = &::std::default::Default::default();
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage3_OneofEmptyField::B = self.oneof_empty_field {
-      let val: &::proto_google::protobuf::empty::Empty = &::std::default::Default::default();
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage3_OneofEmptyField::C(ref val) = self.oneof_empty_field {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-     {
-      let val = &self.nested;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.nested_nullable {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    for val in &self.nested_repeated {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     if self.fixed_length != <[u8; 4] as ::std::default::Default>::default() {
       let val = &self.fixed_length;
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
@@ -4535,22 +4210,6 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage {
     size += n_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let TestMessage3_NestedMessage_NestedOneof::F(ref val) = self.nested_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage3_NestedMessage_NestedOneof::D(ref val) = self.nested_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage3_NestedMessage_NestedOneof::E(ref val) = self.nested_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage3_NestedMessage_NestedOneof::N(ref val) = self.nested_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let TestMessage3_NestedMessage_NestedOneof::F(ref val) = self.nested_oneof {
       ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -4744,17 +4403,6 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage_File {
     size += ::pb_jelly::helpers::compute_size_scalar::<u32>(&self.size, 2, ::pb_jelly::wire_format::Type::Varint);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.blocklist {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.size != <u32 as ::std::default::Default>::default() {
-      let val = &self.size;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     for val in &self.blocklist {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -4833,9 +4481,6 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage_Dir {
   fn compute_size(&self) -> usize {
     0
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    0
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     Ok(())
   }
@@ -4912,14 +4557,6 @@ impl ::pb_jelly::Message for TestBoxedNonnullable {
       field_size += l;
     }
     size += field_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-     {
-      let val = &*self.field;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -5046,20 +4683,6 @@ impl ::pb_jelly::Message for TestMessage3NonNullableOneof {
     }
     size += b_size;
     size += ::pb_jelly::helpers::compute_size_scalar::<u64>(&self.other_field, 3, ::pb_jelly::wire_format::Type::Varint);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let TestMessage3NonNullableOneof_NonNullableOneof::A(ref val) = self.non_nullable_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestMessage3NonNullableOneof_NonNullableOneof::B(ref val) = self.non_nullable_oneof {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.other_field != <u64 as ::std::default::Default>::default() {
-      let val = &self.other_field;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -5199,12 +4822,6 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnum {
     size += field_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    let val = &self.field;
-    size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     let val = &self.field;
     ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
@@ -5320,16 +4937,6 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnumOneof {
       nothing_size += l;
     }
     size += nothing_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(TestMessage3ErrIfDefaultEnumOneof_Maybe::Something(ref val)) = self.maybe {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.nothing {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -5450,13 +5057,6 @@ impl ::pb_jelly::Message for TestMessage3RepeatedErrIfDefaultEnum {
     size += field_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.field {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if !self.field.is_empty() {
       let mut size = 0;
@@ -5544,14 +5144,6 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum {
     size += ::pb_jelly::helpers::compute_size_scalar::<TestMessage3ClosedEnum_ClosedEnum>(&self.value, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.value != <TestMessage3ClosedEnum_ClosedEnum as ::std::default::Default>::default() {
-      let val = &self.value;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, TestMessage3ClosedEnum_ClosedEnum>(w, &self.value, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
@@ -5628,14 +5220,6 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum2 {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<TestMessage3ClosedEnum2_ClosedEnum>(&self.value, 1, ::pb_jelly::wire_format::Type::Varint);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.value != <TestMessage3ClosedEnum2_ClosedEnum as ::std::default::Default>::default() {
-      let val = &self.value;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -5724,14 +5308,6 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage {
     size += msg_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-     {
-      let val = &*self.msg;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
      {
       let val = &*self.msg;
@@ -5816,14 +5392,6 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage_InnerMessage {
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.name, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.name != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.name;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.name, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
@@ -5903,14 +5471,6 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized1 {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size += self._unrecognized.len();
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.string1;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -6153,66 +5713,6 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized2 {
     size += self._unrecognized.len();
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.a_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.a_string1;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.a_int32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.a_int64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.a_uint32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.a_uint64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.a_fixed64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.a_fixed32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.a_sfixed64;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.a_sfixed32;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.a_double;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.a_bool;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.a_string;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.a_bytes;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if self.a_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.a_float;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.a_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.a_int32, 2, ::pb_jelly::wire_format::Type::Varint)?;
@@ -6389,9 +5889,6 @@ impl ::pb_jelly::Message for TestPreserveUnrecognizedEmpty {
     size += self._unrecognized.len();
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    0
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     w.write_all(&self._unrecognized)?;
     Ok(())
@@ -6463,14 +5960,6 @@ impl ::pb_jelly::Message for TestSmallString {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -6551,14 +6040,6 @@ impl ::pb_jelly::Message for TestBoxedSmallString {
     size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, ::compact_str::CompactString>(w, &self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
@@ -6635,14 +6116,6 @@ impl ::pb_jelly::Message for TestNonOptionalSmallString {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -6724,14 +6197,6 @@ impl ::pb_jelly::Message for TestSmallStringPreserveUnrecognized {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size += self._unrecognized.len();
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.compact != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.compact;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -7147,64 +6612,6 @@ impl ::pb_jelly::Message for TestProto3Optional {
     size += real_oneof_2_2_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.a_message {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_int32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_int64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_uint32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_uint64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_fixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_fixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_sfixed64 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_sfixed32 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_double {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_bool {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_string {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_bytes {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(ref val) = self.a_float {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestProto3Optional_RealOneof1::RealOneof11(ref val)) = self.real_oneof_1 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(TestProto3Optional_RealOneof1::RealOneof12(ref val)) = self.real_oneof_1 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestProto3Optional_RealOneof2::RealOneof21(ref val) = self.real_oneof_2 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let TestProto3Optional_RealOneof2::RealOneof22(ref val) = self.real_oneof_2 {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.a_message {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -7617,6 +7024,103 @@ impl ::pb_jelly::Reflection for TestProto3Zerocopy {
   }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct TestProto3ContainsZerocopy {
+  pub inner: ::std::option::Option<TestProto3Zerocopy>,
+}
+impl ::std::default::Default for TestProto3ContainsZerocopy {
+  fn default() -> Self {
+    TestProto3ContainsZerocopy {
+      inner: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref TestProto3ContainsZerocopy_default: TestProto3ContainsZerocopy = TestProto3ContainsZerocopy::default();
+}
+impl ::pb_jelly::Message for TestProto3ContainsZerocopy {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "TestProto3ContainsZerocopy",
+      full_name: "pbtest.TestProto3ContainsZerocopy",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "inner",
+          full_name: "pbtest.TestProto3ContainsZerocopy.inner",
+          index: 0,
+          number: 1,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut inner_size = 0;
+    if let Some(ref val) = self.inner {
+      let l = ::pb_jelly::Message::compute_size(val);
+      inner_size += ::pb_jelly::wire_format::serialized_length(1);
+      inner_size += ::pb_jelly::varint::serialized_length(l as u64);
+      inner_size += l;
+    }
+    size += inner_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize {
+    let mut size = 0;
+    if let Some(ref val) = self.inner {
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if let Some(ref val) = self.inner {
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, TestProto3Zerocopy>(buf, typ, "TestProto3ContainsZerocopy", 1)?;
+          self.inner = Some(val);
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for TestProto3ContainsZerocopy {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "inner" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.inner.get_or_insert_with(::std::default::Default::default))
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RecursiveOneof {
   /// This field should be boxed automatically.
@@ -7746,29 +7250,6 @@ impl ::pb_jelly::Message for RecursiveOneof {
       boxed_size += l;
     }
     size += boxed_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(RecursiveOneof_OneofField::Field(ref val)) = self.oneof_field {
-      let val: &RecursiveOneof = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(RecursiveOneof_OneofField::Empty) = self.oneof_field {
-      let val: &::proto_google::protobuf::empty::Empty = &::std::default::Default::default();
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(RecursiveOneof_OneofField::BoxedEmpty(ref val)) = self.oneof_field {
-      let val: &::proto_google::protobuf::empty::Empty = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(RecursiveOneof_OneofField::NotBoxed(ref val)) = self.oneof_field {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    if let Some(RecursiveOneof_OneofField::Boxed(ref val)) = self.oneof_field {
-      let val: &ForeignMessage3 = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -7984,13 +7465,6 @@ impl ::pb_jelly::Message for MentionsKeywordPath {
     size += message_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let Some(ref val) = self.message {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     if let Some(ref val) = self.message {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -8085,13 +7559,6 @@ impl ::pb_jelly::Message for NonNullableOneofKeyword {
       a_size += l;
     }
     size += a_size;
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if let NonNullableOneofKeyword_Async::A(ref val) = self.r#async {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
@@ -8194,12 +7661,6 @@ impl ::pb_jelly::Message for NonNullableEnumKeyword {
     size += enum_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    let val = &self.r#enum;
-    size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     let val = &self.r#enum;
     ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
@@ -8283,7 +7744,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveA {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut inner_size = 0;
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let val = &**val;
       let l = ::pb_jelly::Message::compute_size(val);
       inner_size += ::pb_jelly::wire_format::serialized_length(1);
@@ -8293,16 +7754,8 @@ impl ::pb_jelly::Message for MutuallyRecursiveA {
     size += inner_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.inner {
-      let val = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let val = &**val;
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
@@ -8315,11 +7768,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveA {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MutuallyRecursiveA", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: MutuallyRecursiveB = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, MutuallyRecursiveB>(buf, typ, "MutuallyRecursiveA", 1)?;
           self.inner = Some(Box::new(val));
         }
         _ => {
@@ -8387,7 +7836,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveB {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut inner_size = 0;
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let val = &**val;
       let l = ::pb_jelly::Message::compute_size(val);
       inner_size += ::pb_jelly::wire_format::serialized_length(1);
@@ -8397,16 +7846,8 @@ impl ::pb_jelly::Message for MutuallyRecursiveB {
     size += inner_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.inner {
-      let val = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let val = &**val;
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
@@ -8419,11 +7860,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveB {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MutuallyRecursiveB", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: MutuallyRecursiveA = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, MutuallyRecursiveA>(buf, typ, "MutuallyRecursiveB", 1)?;
           self.inner = Some(Box::new(val));
         }
         _ => {
@@ -8500,13 +7937,6 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithRepeatedA {
     size += inner_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.inner {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     for val in &self.inner {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
@@ -8520,11 +7950,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithRepeatedA {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MutuallyRecursiveWithRepeatedA", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: MutuallyRecursiveWithRepeatedB = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, MutuallyRecursiveWithRepeatedB>(buf, typ, "MutuallyRecursiveWithRepeatedA", 1)?;
           self.inner.push(val);
         }
         _ => {
@@ -8594,7 +8020,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithRepeatedB {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut inner_size = 0;
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let l = ::pb_jelly::Message::compute_size(val);
       inner_size += ::pb_jelly::wire_format::serialized_length(1);
       inner_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -8603,15 +8029,8 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithRepeatedB {
     size += inner_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.inner {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -8623,11 +8042,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithRepeatedB {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MutuallyRecursiveWithRepeatedB", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: MutuallyRecursiveWithRepeatedA = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, MutuallyRecursiveWithRepeatedA>(buf, typ, "MutuallyRecursiveWithRepeatedB", 1)?;
           self.inner = Some(val);
         }
         _ => {
@@ -8695,7 +8110,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithBoxedA {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut inner_size = 0;
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let val = &**val;
       let l = ::pb_jelly::Message::compute_size(val);
       inner_size += ::pb_jelly::wire_format::serialized_length(1);
@@ -8705,16 +8120,8 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithBoxedA {
     size += inner_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.inner {
-      let val = &**val;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let val = &**val;
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
@@ -8727,11 +8134,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithBoxedA {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MutuallyRecursiveWithBoxedA", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: MutuallyRecursiveWithBoxedB = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, MutuallyRecursiveWithBoxedB>(buf, typ, "MutuallyRecursiveWithBoxedA", 1)?;
           self.inner = Some(Box::new(val));
         }
         _ => {
@@ -8800,7 +8203,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithBoxedB {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut inner_size = 0;
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       let l = ::pb_jelly::Message::compute_size(val);
       inner_size += ::pb_jelly::wire_format::serialized_length(1);
       inner_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -8809,15 +8212,8 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithBoxedB {
     size += inner_size;
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    for val in &self.inner {
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.inner {
+    if let Some(ref val) = self.inner {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -8829,11 +8225,7 @@ impl ::pb_jelly::Message for MutuallyRecursiveWithBoxedB {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MutuallyRecursiveWithBoxedB", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: MutuallyRecursiveWithBoxedA = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, MutuallyRecursiveWithBoxedA>(buf, typ, "MutuallyRecursiveWithBoxedB", 1)?;
           self.inner = Some(val);
         }
         _ => {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -739,11 +739,7 @@ impl ::pb_jelly::Message for ForeignMessage3 {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.c != <i32 as ::std::default::Default>::default() {
-      let val = &self.c;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.c, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -1219,11 +1215,7 @@ impl ::pb_jelly::Message for Version31Enum {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.enum_field != <Version31Enum_TestEnum as ::std::default::Default>::default() {
-      let val = &self.enum_field;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, Version31Enum_TestEnum>(w, &self.enum_field, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -1316,11 +1308,7 @@ impl ::pb_jelly::Message for Version32Enum {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.enum_field != <Version32Enum_TestEnum as ::std::default::Default>::default() {
-      let val = &self.enum_field;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, Version32Enum_TestEnum>(w, &self.enum_field, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -1695,13 +1683,7 @@ impl ::pb_jelly::Message for Version31 {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.optional_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -1795,13 +1777,7 @@ impl ::pb_jelly::Message for Version31SSO {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.optional_string1 != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::compact_str::CompactString>(w, &self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -2196,82 +2172,20 @@ impl ::pb_jelly::Message for Version32 {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.optional_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.optional_int32;
-      ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.optional_int64;
-      ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.optional_uint32;
-      ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.optional_uint64;
-      ::pb_jelly::wire_format::write(5, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed64;
-      ::pb_jelly::wire_format::write(6, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed32;
-      ::pb_jelly::wire_format::write(7, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed64;
-      ::pb_jelly::wire_format::write(8, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed32;
-      ::pb_jelly::wire_format::write(9, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.optional_double;
-      ::pb_jelly::wire_format::write(10, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.optional_bool;
-      ::pb_jelly::wire_format::write(11, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string;
-      ::pb_jelly::wire_format::write(12, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.optional_bytes;
-      ::pb_jelly::wire_format::write(13, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.optional_float;
-      ::pb_jelly::wire_format::write(14, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.optional_int32, 2, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, i64>(w, &self.optional_int64, 3, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, u32>(w, &self.optional_uint32, 4, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, u64>(w, &self.optional_uint64, 5, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Fixed64>(w, &self.optional_fixed64, 6, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Fixed32>(w, &self.optional_fixed32, 7, ::pb_jelly::wire_format::Type::Fixed32)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Sfixed64>(w, &self.optional_sfixed64, 8, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Sfixed32>(w, &self.optional_sfixed32, 9, ::pb_jelly::wire_format::Type::Fixed32)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, f64>(w, &self.optional_double, 10, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, bool>(w, &self.optional_bool, 11, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.optional_string, 12, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::vec::Vec<u8>>(w, &self.optional_bytes, 13, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, f32>(w, &self.optional_float, 14, ::pb_jelly::wire_format::Type::Fixed32)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -3822,91 +3736,27 @@ impl ::pb_jelly::Message for TestMessage3 {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.optional_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.optional_int32;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.optional_int64;
-      ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.optional_uint32;
-      ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.optional_uint64;
-      ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed64;
-      ::pb_jelly::wire_format::write(8, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed32;
-      ::pb_jelly::wire_format::write(9, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed64;
-      ::pb_jelly::wire_format::write(10, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed32;
-      ::pb_jelly::wire_format::write(11, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.optional_double;
-      ::pb_jelly::wire_format::write(12, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.optional_bool;
-      ::pb_jelly::wire_format::write(13, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string;
-      ::pb_jelly::wire_format::write(14, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.optional_bytes;
-      ::pb_jelly::wire_format::write(15, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.optional_float;
-      ::pb_jelly::wire_format::write(16, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.optional_int32, 1, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, i64>(w, &self.optional_int64, 2, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, u32>(w, &self.optional_uint32, 3, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, u64>(w, &self.optional_uint64, 4, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Fixed64>(w, &self.optional_fixed64, 8, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Fixed32>(w, &self.optional_fixed32, 9, ::pb_jelly::wire_format::Type::Fixed32)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Sfixed64>(w, &self.optional_sfixed64, 10, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Sfixed32>(w, &self.optional_sfixed32, 11, ::pb_jelly::wire_format::Type::Fixed32)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, f64>(w, &self.optional_double, 12, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, bool>(w, &self.optional_bool, 13, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.optional_string, 14, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::vec::Vec<u8>>(w, &self.optional_bytes, 15, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, f32>(w, &self.optional_float, 16, ::pb_jelly::wire_format::Type::Fixed32)?;
     for val in &self.optional_foreign_message {
       ::pb_jelly::wire_format::write(19, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    if self.optional_nested_enum != <TestMessage3_NestedEnum3 as ::std::default::Default>::default() {
-      let val = &self.optional_nested_enum;
-      ::pb_jelly::wire_format::write(21, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.optional_foreign_enum != <ForeignEnum3 as ::std::default::Default>::default() {
-      let val = &self.optional_foreign_enum;
-      ::pb_jelly::wire_format::write(22, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, TestMessage3_NestedEnum3>(w, &self.optional_nested_enum, 21, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ForeignEnum3>(w, &self.optional_foreign_enum, 22, ::pb_jelly::wire_format::Type::Varint)?;
     if !self.repeated_int32.is_empty() {
       let mut size = 0;
       for val in &self.repeated_int32 {
@@ -4195,26 +4045,14 @@ impl ::pb_jelly::Message for TestMessage3 {
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    if self.fixed_length != <[u8; 4] as ::std::default::Default>::default() {
-      let val = &self.fixed_length;
-      ::pb_jelly::wire_format::write(76, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, [u8; 4]>(w, &self.fixed_length, 76, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     for val in &self.fixed_length_repeated {
       ::pb_jelly::wire_format::write(77, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    if self.zero_or_fixed_length != <Option<[u8; 4]> as ::std::default::Default>::default() {
-      let val = &self.zero_or_fixed_length;
-      ::pb_jelly::wire_format::write(78, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, Option<[u8; 4]>>(w, &self.zero_or_fixed_length, 78, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     for val in &self.zero_or_fixed_length_repeated {
       ::pb_jelly::wire_format::write(79, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
@@ -5192,11 +5030,7 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage_File {
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    if self.size != <u32 as ::std::default::Default>::default() {
-      let val = &self.size;
-      ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, u32>(w, &self.size, 2, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -5512,11 +5346,7 @@ impl ::pb_jelly::Message for TestMessage3NonNullableOneof {
       ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    if self.other_field != <u64 as ::std::default::Default>::default() {
-      let val = &self.other_field;
-      ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, u64>(w, &self.other_field, 3, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -6005,11 +5835,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.value != <TestMessage3ClosedEnum_ClosedEnum as ::std::default::Default>::default() {
-      let val = &self.value;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, TestMessage3ClosedEnum_ClosedEnum>(w, &self.value, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -6102,11 +5928,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum2 {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.value != <TestMessage3ClosedEnum2_ClosedEnum as ::std::default::Default>::default() {
-      let val = &self.value;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, TestMessage3ClosedEnum2_ClosedEnum>(w, &self.value, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -6300,13 +6122,7 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage_InnerMessage {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.name != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.name;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.name, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -6403,13 +6219,7 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized1 {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.string1;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     w.write_all(&self._unrecognized)?;
     Ok(())
   }
@@ -6810,82 +6620,20 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized2 {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.a_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.a_string1;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.a_int32;
-      ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.a_int64;
-      ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.a_uint32;
-      ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.a_uint64;
-      ::pb_jelly::wire_format::write(5, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.a_fixed64;
-      ::pb_jelly::wire_format::write(6, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.a_fixed32;
-      ::pb_jelly::wire_format::write(7, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.a_sfixed64;
-      ::pb_jelly::wire_format::write(8, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.a_sfixed32;
-      ::pb_jelly::wire_format::write(9, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.a_double;
-      ::pb_jelly::wire_format::write(10, ::pb_jelly::wire_format::Type::Fixed64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.a_bool;
-      ::pb_jelly::wire_format::write(11, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.a_string;
-      ::pb_jelly::wire_format::write(12, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.a_bytes;
-      ::pb_jelly::wire_format::write(13, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.a_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.a_float;
-      ::pb_jelly::wire_format::write(14, ::pb_jelly::wire_format::Type::Fixed32, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.a_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.a_int32, 2, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, i64>(w, &self.a_int64, 3, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, u32>(w, &self.a_uint32, 4, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, u64>(w, &self.a_uint64, 5, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Fixed64>(w, &self.a_fixed64, 6, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Fixed32>(w, &self.a_fixed32, 7, ::pb_jelly::wire_format::Type::Fixed32)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Sfixed64>(w, &self.a_sfixed64, 8, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Sfixed32>(w, &self.a_sfixed32, 9, ::pb_jelly::wire_format::Type::Fixed32)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, f64>(w, &self.a_double, 10, ::pb_jelly::wire_format::Type::Fixed64)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, bool>(w, &self.a_bool, 11, ::pb_jelly::wire_format::Type::Varint)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.a_string, 12, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::vec::Vec<u8>>(w, &self.a_bytes, 13, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, f32>(w, &self.a_float, 14, ::pb_jelly::wire_format::Type::Fixed32)?;
     w.write_all(&self._unrecognized)?;
     Ok(())
   }
@@ -7140,13 +6888,7 @@ impl ::pb_jelly::Message for TestSmallString {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::compact_str::CompactString>(w, &self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -7240,13 +6982,7 @@ impl ::pb_jelly::Message for TestBoxedSmallString {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::compact_str::CompactString>(w, &self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -7340,13 +7076,7 @@ impl ::pb_jelly::Message for TestNonOptionalSmallString {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::compact_str::CompactString>(w, &self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -7443,13 +7173,7 @@ impl ::pb_jelly::Message for TestSmallStringPreserveUnrecognized {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.compact != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.compact;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     w.write_all(&self._unrecognized)?;
     Ok(())
   }
@@ -8301,20 +8025,8 @@ impl ::pb_jelly::Message for TestProto3Zerocopy {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.data1 != <::pb_jelly::Lazy<::bytes::Bytes> as ::std::default::Default>::default() {
-      let val = &self.data1;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
-    if self.data2 != <::pb_jelly::Lazy<::bytes::Bytes> as ::std::default::Default>::default() {
-      let val = &self.data2;
-      ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
-      let l = ::pb_jelly::Message::compute_size(val);
-      ::pb_jelly::varint::write(l as u64, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Lazy<::bytes::Bytes>>(w, &self.data1, 1, ::pb_jelly::wire_format::Type::LengthDelimited)?;
+    ::pb_jelly::helpers::serialize_scalar::<W, ::pb_jelly::Lazy<::bytes::Bytes>>(w, &self.data2, 2, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -2907,7 +2907,7 @@ impl ::pb_jelly::Message for TestMessage3 {
     size += ::pb_jelly::helpers::compute_size_scalar::<::std::vec::Vec<u8>>(&self.optional_bytes, 15, ::pb_jelly::wire_format::Type::LengthDelimited);
     size += ::pb_jelly::helpers::compute_size_scalar::<f32>(&self.optional_float, 16, ::pb_jelly::wire_format::Type::Fixed32);
     let mut optional_foreign_message_size = 0;
-    for val in &self.optional_foreign_message {
+    if let Some(ref val) = self.optional_foreign_message {
       let l = ::pb_jelly::Message::compute_size(val);
       optional_foreign_message_size += ::pb_jelly::wire_format::serialized_length(19);
       optional_foreign_message_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3071,7 +3071,7 @@ impl ::pb_jelly::Message for TestMessage3 {
     }
     size += repeated_foreign_enum_size;
     let mut proto2_msg_size = 0;
-    for val in &self.proto2_msg {
+    if let Some(ref val) = self.proto2_msg {
       let l = ::pb_jelly::Message::compute_size(val);
       proto2_msg_size += ::pb_jelly::wire_format::serialized_length(53);
       proto2_msg_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3079,7 +3079,7 @@ impl ::pb_jelly::Message for TestMessage3 {
     }
     size += proto2_msg_size;
     let mut proto2_msg_empty_size = 0;
-    for val in &self.proto2_msg_empty {
+    if let Some(ref val) = self.proto2_msg_empty {
       let l = ::pb_jelly::Message::compute_size(val);
       proto2_msg_empty_size += ::pb_jelly::wire_format::serialized_length(54);
       proto2_msg_empty_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3087,7 +3087,7 @@ impl ::pb_jelly::Message for TestMessage3 {
     }
     size += proto2_msg_empty_size;
     let mut proto2_msg_missing_size = 0;
-    for val in &self.proto2_msg_missing {
+    if let Some(ref val) = self.proto2_msg_missing {
       let l = ::pb_jelly::Message::compute_size(val);
       proto2_msg_missing_size += ::pb_jelly::wire_format::serialized_length(55);
       proto2_msg_missing_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3095,7 +3095,7 @@ impl ::pb_jelly::Message for TestMessage3 {
     }
     size += proto2_msg_missing_size;
     let mut optional_foreign_message_boxed_size = 0;
-    for val in &self.optional_foreign_message_boxed {
+    if let Some(ref val) = self.optional_foreign_message_boxed {
       let val = &**val;
       let l = ::pb_jelly::Message::compute_size(val);
       optional_foreign_message_boxed_size += ::pb_jelly::wire_format::serialized_length(56);
@@ -3236,7 +3236,7 @@ impl ::pb_jelly::Message for TestMessage3 {
     }
     size += nested_size;
     let mut nested_nullable_size = 0;
-    for val in &self.nested_nullable {
+    if let Some(ref val) = self.nested_nullable {
       let l = ::pb_jelly::Message::compute_size(val);
       nested_nullable_size += ::pb_jelly::wire_format::serialized_length(74);
       nested_nullable_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -3325,7 +3325,7 @@ impl ::pb_jelly::Message for TestMessage3 {
       let val = &self.optional_float;
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_foreign_message {
+    if let Some(ref val) = self.optional_foreign_message {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     if self.optional_nested_enum != <TestMessage3_NestedEnum3 as ::std::default::Default>::default() {
@@ -3384,16 +3384,16 @@ impl ::pb_jelly::Message for TestMessage3 {
     for val in &self.repeated_foreign_enum {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.proto2_msg {
+    if let Some(ref val) = self.proto2_msg {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.proto2_msg_empty {
+    if let Some(ref val) = self.proto2_msg_empty {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.proto2_msg_missing {
+    if let Some(ref val) = self.proto2_msg_missing {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.optional_foreign_message_boxed {
+    if let Some(ref val) = self.optional_foreign_message_boxed {
       let val = &**val;
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
@@ -3452,7 +3452,7 @@ impl ::pb_jelly::Message for TestMessage3 {
       let val = &self.nested;
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.nested_nullable {
+    if let Some(ref val) = self.nested_nullable {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     for val in &self.nested_repeated {
@@ -3488,7 +3488,7 @@ impl ::pb_jelly::Message for TestMessage3 {
     ::pb_jelly::helpers::serialize_scalar::<W, ::std::string::String>(w, &self.optional_string, 14, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     ::pb_jelly::helpers::serialize_scalar::<W, ::std::vec::Vec<u8>>(w, &self.optional_bytes, 15, ::pb_jelly::wire_format::Type::LengthDelimited)?;
     ::pb_jelly::helpers::serialize_scalar::<W, f32>(w, &self.optional_float, 16, ::pb_jelly::wire_format::Type::Fixed32)?;
-    for val in &self.optional_foreign_message {
+    if let Some(ref val) = self.optional_foreign_message {
       ::pb_jelly::wire_format::write(19, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -3657,25 +3657,25 @@ impl ::pb_jelly::Message for TestMessage3 {
     for val in &self.repeated_foreign_enum {
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.proto2_msg {
+    if let Some(ref val) = self.proto2_msg {
       ::pb_jelly::wire_format::write(53, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.proto2_msg_empty {
+    if let Some(ref val) = self.proto2_msg_empty {
       ::pb_jelly::wire_format::write(54, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.proto2_msg_missing {
+    if let Some(ref val) = self.proto2_msg_missing {
       ::pb_jelly::wire_format::write(55, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.optional_foreign_message_boxed {
+    if let Some(ref val) = self.optional_foreign_message_boxed {
       let val = &**val;
       ::pb_jelly::wire_format::write(56, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
@@ -3772,7 +3772,7 @@ impl ::pb_jelly::Message for TestMessage3 {
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.nested_nullable {
+    if let Some(ref val) = self.nested_nullable {
       ::pb_jelly::wire_format::write(74, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -5313,7 +5313,7 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnumOneof {
     }
     size += something_size;
     let mut nothing_size = 0;
-    for val in &self.nothing {
+    if let Some(ref val) = self.nothing {
       let l = ::pb_jelly::Message::compute_size(val);
       nothing_size += ::pb_jelly::wire_format::serialized_length(2);
       nothing_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -5327,7 +5327,7 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnumOneof {
     if let Some(TestMessage3ErrIfDefaultEnumOneof_Maybe::Something(ref val)) = self.maybe {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.nothing {
+    if let Some(ref val) = self.nothing {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
@@ -5337,7 +5337,7 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnumOneof {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.nothing {
+    if let Some(ref val) = self.nothing {
       ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
@@ -7013,7 +7013,7 @@ impl ::pb_jelly::Message for TestProto3Optional {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut a_message_size = 0;
-    for val in &self.a_message {
+    if let Some(ref val) = self.a_message {
       let l = ::pb_jelly::Message::compute_size(val);
       a_message_size += ::pb_jelly::wire_format::serialized_length(1);
       a_message_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -7021,77 +7021,77 @@ impl ::pb_jelly::Message for TestProto3Optional {
     }
     size += a_message_size;
     let mut a_int32_size = 0;
-    for val in &self.a_int32 {
+    if let Some(ref val) = self.a_int32 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_int32_size += ::pb_jelly::wire_format::serialized_length(2);
       a_int32_size += l;
     }
     size += a_int32_size;
     let mut a_int64_size = 0;
-    for val in &self.a_int64 {
+    if let Some(ref val) = self.a_int64 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_int64_size += ::pb_jelly::wire_format::serialized_length(3);
       a_int64_size += l;
     }
     size += a_int64_size;
     let mut a_uint32_size = 0;
-    for val in &self.a_uint32 {
+    if let Some(ref val) = self.a_uint32 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_uint32_size += ::pb_jelly::wire_format::serialized_length(4);
       a_uint32_size += l;
     }
     size += a_uint32_size;
     let mut a_uint64_size = 0;
-    for val in &self.a_uint64 {
+    if let Some(ref val) = self.a_uint64 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_uint64_size += ::pb_jelly::wire_format::serialized_length(5);
       a_uint64_size += l;
     }
     size += a_uint64_size;
     let mut a_fixed64_size = 0;
-    for val in &self.a_fixed64 {
+    if let Some(ref val) = self.a_fixed64 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_fixed64_size += ::pb_jelly::wire_format::serialized_length(6);
       a_fixed64_size += l;
     }
     size += a_fixed64_size;
     let mut a_fixed32_size = 0;
-    for val in &self.a_fixed32 {
+    if let Some(ref val) = self.a_fixed32 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_fixed32_size += ::pb_jelly::wire_format::serialized_length(7);
       a_fixed32_size += l;
     }
     size += a_fixed32_size;
     let mut a_sfixed64_size = 0;
-    for val in &self.a_sfixed64 {
+    if let Some(ref val) = self.a_sfixed64 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_sfixed64_size += ::pb_jelly::wire_format::serialized_length(8);
       a_sfixed64_size += l;
     }
     size += a_sfixed64_size;
     let mut a_sfixed32_size = 0;
-    for val in &self.a_sfixed32 {
+    if let Some(ref val) = self.a_sfixed32 {
       let l = ::pb_jelly::Message::compute_size(val);
       a_sfixed32_size += ::pb_jelly::wire_format::serialized_length(9);
       a_sfixed32_size += l;
     }
     size += a_sfixed32_size;
     let mut a_double_size = 0;
-    for val in &self.a_double {
+    if let Some(ref val) = self.a_double {
       let l = ::pb_jelly::Message::compute_size(val);
       a_double_size += ::pb_jelly::wire_format::serialized_length(10);
       a_double_size += l;
     }
     size += a_double_size;
     let mut a_bool_size = 0;
-    for val in &self.a_bool {
+    if let Some(ref val) = self.a_bool {
       let l = ::pb_jelly::Message::compute_size(val);
       a_bool_size += ::pb_jelly::wire_format::serialized_length(11);
       a_bool_size += l;
     }
     size += a_bool_size;
     let mut a_string_size = 0;
-    for val in &self.a_string {
+    if let Some(ref val) = self.a_string {
       let l = ::pb_jelly::Message::compute_size(val);
       a_string_size += ::pb_jelly::wire_format::serialized_length(12);
       a_string_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -7099,7 +7099,7 @@ impl ::pb_jelly::Message for TestProto3Optional {
     }
     size += a_string_size;
     let mut a_bytes_size = 0;
-    for val in &self.a_bytes {
+    if let Some(ref val) = self.a_bytes {
       let l = ::pb_jelly::Message::compute_size(val);
       a_bytes_size += ::pb_jelly::wire_format::serialized_length(13);
       a_bytes_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -7107,7 +7107,7 @@ impl ::pb_jelly::Message for TestProto3Optional {
     }
     size += a_bytes_size;
     let mut a_float_size = 0;
-    for val in &self.a_float {
+    if let Some(ref val) = self.a_float {
       let l = ::pb_jelly::Message::compute_size(val);
       a_float_size += ::pb_jelly::wire_format::serialized_length(14);
       a_float_size += l;
@@ -7149,46 +7149,46 @@ impl ::pb_jelly::Message for TestProto3Optional {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.a_message {
+    if let Some(ref val) = self.a_message {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_int32 {
+    if let Some(ref val) = self.a_int32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_int64 {
+    if let Some(ref val) = self.a_int64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_uint32 {
+    if let Some(ref val) = self.a_uint32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_uint64 {
+    if let Some(ref val) = self.a_uint64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_fixed64 {
+    if let Some(ref val) = self.a_fixed64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_fixed32 {
+    if let Some(ref val) = self.a_fixed32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_sfixed64 {
+    if let Some(ref val) = self.a_sfixed64 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_sfixed32 {
+    if let Some(ref val) = self.a_sfixed32 {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_double {
+    if let Some(ref val) = self.a_double {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_bool {
+    if let Some(ref val) = self.a_bool {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_string {
+    if let Some(ref val) = self.a_string {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_bytes {
+    if let Some(ref val) = self.a_bytes {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
-    for val in &self.a_float {
+    if let Some(ref val) = self.a_float {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     if let Some(TestProto3Optional_RealOneof1::RealOneof11(ref val)) = self.real_oneof_1 {
@@ -7206,65 +7206,65 @@ impl ::pb_jelly::Message for TestProto3Optional {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.a_message {
+    if let Some(ref val) = self.a_message {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_int32 {
+    if let Some(ref val) = self.a_int32 {
       ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_int64 {
+    if let Some(ref val) = self.a_int64 {
       ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_uint32 {
+    if let Some(ref val) = self.a_uint32 {
       ::pb_jelly::wire_format::write(4, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_uint64 {
+    if let Some(ref val) = self.a_uint64 {
       ::pb_jelly::wire_format::write(5, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_fixed64 {
+    if let Some(ref val) = self.a_fixed64 {
       ::pb_jelly::wire_format::write(6, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_fixed32 {
+    if let Some(ref val) = self.a_fixed32 {
       ::pb_jelly::wire_format::write(7, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_sfixed64 {
+    if let Some(ref val) = self.a_sfixed64 {
       ::pb_jelly::wire_format::write(8, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_sfixed32 {
+    if let Some(ref val) = self.a_sfixed32 {
       ::pb_jelly::wire_format::write(9, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_double {
+    if let Some(ref val) = self.a_double {
       ::pb_jelly::wire_format::write(10, ::pb_jelly::wire_format::Type::Fixed64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_bool {
+    if let Some(ref val) = self.a_bool {
       ::pb_jelly::wire_format::write(11, ::pb_jelly::wire_format::Type::Varint, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_string {
+    if let Some(ref val) = self.a_string {
       ::pb_jelly::wire_format::write(12, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_bytes {
+    if let Some(ref val) = self.a_bytes {
       ::pb_jelly::wire_format::write(13, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
-    for val in &self.a_float {
+    if let Some(ref val) = self.a_float {
       ::pb_jelly::wire_format::write(14, ::pb_jelly::wire_format::Type::Fixed32, w)?;
       ::pb_jelly::Message::serialize(val, w)?;
     }
@@ -7975,7 +7975,7 @@ impl ::pb_jelly::Message for MentionsKeywordPath {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     let mut message_size = 0;
-    for val in &self.message {
+    if let Some(ref val) = self.message {
       let l = ::pb_jelly::Message::compute_size(val);
       message_size += ::pb_jelly::wire_format::serialized_length(1);
       message_size += ::pb_jelly::varint::serialized_length(l as u64);
@@ -7986,13 +7986,13 @@ impl ::pb_jelly::Message for MentionsKeywordPath {
   }
   fn compute_grpc_slices_size(&self) -> usize {
     let mut size = 0;
-    for val in &self.message {
+    if let Some(ref val) = self.message {
       size += ::pb_jelly::Message::compute_grpc_slices_size(val);
     }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    for val in &self.message {
+    if let Some(ref val) = self.message {
       ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
       let l = ::pb_jelly::Message::compute_size(val);
       ::pb_jelly::varint::write(l as u64, w)?;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -720,14 +720,7 @@ impl ::pb_jelly::Message for ForeignMessage3 {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut c_size = 0;
-    if self.c != <i32 as ::std::default::Default>::default() {
-      let val = &self.c;
-      let l = ::pb_jelly::Message::compute_size(val);
-      c_size += ::pb_jelly::wire_format::serialized_length(1);
-      c_size += l;
-    }
-    size += c_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.c, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -1196,14 +1189,7 @@ impl ::pb_jelly::Message for Version31Enum {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut enum_field_size = 0;
-    if self.enum_field != <Version31Enum_TestEnum as ::std::default::Default>::default() {
-      let val = &self.enum_field;
-      let l = ::pb_jelly::Message::compute_size(val);
-      enum_field_size += ::pb_jelly::wire_format::serialized_length(1);
-      enum_field_size += l;
-    }
-    size += enum_field_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<Version31Enum_TestEnum>(&self.enum_field, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -1289,14 +1275,7 @@ impl ::pb_jelly::Message for Version32Enum {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut enum_field_size = 0;
-    if self.enum_field != <Version32Enum_TestEnum as ::std::default::Default>::default() {
-      let val = &self.enum_field;
-      let l = ::pb_jelly::Message::compute_size(val);
-      enum_field_size += ::pb_jelly::wire_format::serialized_length(1);
-      enum_field_size += l;
-    }
-    size += enum_field_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<Version32Enum_TestEnum>(&self.enum_field, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -1663,15 +1642,7 @@ impl ::pb_jelly::Message for Version31 {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut optional_string1_size = 0;
-    if self.optional_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_string1_size += ::pb_jelly::wire_format::serialized_length(1);
-      optional_string1_size += ::pb_jelly::varint::serialized_length(l as u64);
-      optional_string1_size += l;
-    }
-    size += optional_string1_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -1757,15 +1728,7 @@ impl ::pb_jelly::Message for Version31SSO {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut optional_string1_size = 0;
-    if self.optional_string1 != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_string1_size += ::pb_jelly::wire_format::serialized_length(1);
-      optional_string1_size += ::pb_jelly::varint::serialized_length(l as u64);
-      optional_string1_size += l;
-    }
-    size += optional_string1_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -1994,121 +1957,20 @@ impl ::pb_jelly::Message for Version32 {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut optional_string1_size = 0;
-    if self.optional_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string1;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_string1_size += ::pb_jelly::wire_format::serialized_length(1);
-      optional_string1_size += ::pb_jelly::varint::serialized_length(l as u64);
-      optional_string1_size += l;
-    }
-    size += optional_string1_size;
-    let mut optional_int32_size = 0;
-    if self.optional_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.optional_int32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_int32_size += ::pb_jelly::wire_format::serialized_length(2);
-      optional_int32_size += l;
-    }
-    size += optional_int32_size;
-    let mut optional_int64_size = 0;
-    if self.optional_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.optional_int64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_int64_size += ::pb_jelly::wire_format::serialized_length(3);
-      optional_int64_size += l;
-    }
-    size += optional_int64_size;
-    let mut optional_uint32_size = 0;
-    if self.optional_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.optional_uint32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_uint32_size += ::pb_jelly::wire_format::serialized_length(4);
-      optional_uint32_size += l;
-    }
-    size += optional_uint32_size;
-    let mut optional_uint64_size = 0;
-    if self.optional_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.optional_uint64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_uint64_size += ::pb_jelly::wire_format::serialized_length(5);
-      optional_uint64_size += l;
-    }
-    size += optional_uint64_size;
-    let mut optional_fixed64_size = 0;
-    if self.optional_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_fixed64_size += ::pb_jelly::wire_format::serialized_length(6);
-      optional_fixed64_size += l;
-    }
-    size += optional_fixed64_size;
-    let mut optional_fixed32_size = 0;
-    if self.optional_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_fixed32_size += ::pb_jelly::wire_format::serialized_length(7);
-      optional_fixed32_size += l;
-    }
-    size += optional_fixed32_size;
-    let mut optional_sfixed64_size = 0;
-    if self.optional_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_sfixed64_size += ::pb_jelly::wire_format::serialized_length(8);
-      optional_sfixed64_size += l;
-    }
-    size += optional_sfixed64_size;
-    let mut optional_sfixed32_size = 0;
-    if self.optional_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_sfixed32_size += ::pb_jelly::wire_format::serialized_length(9);
-      optional_sfixed32_size += l;
-    }
-    size += optional_sfixed32_size;
-    let mut optional_double_size = 0;
-    if self.optional_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.optional_double;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_double_size += ::pb_jelly::wire_format::serialized_length(10);
-      optional_double_size += l;
-    }
-    size += optional_double_size;
-    let mut optional_bool_size = 0;
-    if self.optional_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.optional_bool;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_bool_size += ::pb_jelly::wire_format::serialized_length(11);
-      optional_bool_size += l;
-    }
-    size += optional_bool_size;
-    let mut optional_string_size = 0;
-    if self.optional_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_string_size += ::pb_jelly::wire_format::serialized_length(12);
-      optional_string_size += ::pb_jelly::varint::serialized_length(l as u64);
-      optional_string_size += l;
-    }
-    size += optional_string_size;
-    let mut optional_bytes_size = 0;
-    if self.optional_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.optional_bytes;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_bytes_size += ::pb_jelly::wire_format::serialized_length(13);
-      optional_bytes_size += ::pb_jelly::varint::serialized_length(l as u64);
-      optional_bytes_size += l;
-    }
-    size += optional_bytes_size;
-    let mut optional_float_size = 0;
-    if self.optional_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.optional_float;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_float_size += ::pb_jelly::wire_format::serialized_length(14);
-      optional_float_size += l;
-    }
-    size += optional_float_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.optional_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.optional_int32, 2, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<i64>(&self.optional_int64, 3, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<u32>(&self.optional_uint32, 4, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<u64>(&self.optional_uint64, 5, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Fixed64>(&self.optional_fixed64, 6, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Fixed32>(&self.optional_fixed32, 7, ::pb_jelly::wire_format::Type::Fixed32);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Sfixed64>(&self.optional_sfixed64, 8, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Sfixed32>(&self.optional_sfixed32, 9, ::pb_jelly::wire_format::Type::Fixed32);
+    size += ::pb_jelly::helpers::compute_size_scalar::<f64>(&self.optional_double, 10, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<bool>(&self.optional_bool, 11, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.optional_string, 12, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::vec::Vec<u8>>(&self.optional_bytes, 13, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<f32>(&self.optional_float, 14, ::pb_jelly::wire_format::Type::Fixed32);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -3031,112 +2893,19 @@ impl ::pb_jelly::Message for TestMessage3 {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut optional_int32_size = 0;
-    if self.optional_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.optional_int32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_int32_size += ::pb_jelly::wire_format::serialized_length(1);
-      optional_int32_size += l;
-    }
-    size += optional_int32_size;
-    let mut optional_int64_size = 0;
-    if self.optional_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.optional_int64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_int64_size += ::pb_jelly::wire_format::serialized_length(2);
-      optional_int64_size += l;
-    }
-    size += optional_int64_size;
-    let mut optional_uint32_size = 0;
-    if self.optional_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.optional_uint32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_uint32_size += ::pb_jelly::wire_format::serialized_length(3);
-      optional_uint32_size += l;
-    }
-    size += optional_uint32_size;
-    let mut optional_uint64_size = 0;
-    if self.optional_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.optional_uint64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_uint64_size += ::pb_jelly::wire_format::serialized_length(4);
-      optional_uint64_size += l;
-    }
-    size += optional_uint64_size;
-    let mut optional_fixed64_size = 0;
-    if self.optional_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_fixed64_size += ::pb_jelly::wire_format::serialized_length(8);
-      optional_fixed64_size += l;
-    }
-    size += optional_fixed64_size;
-    let mut optional_fixed32_size = 0;
-    if self.optional_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_fixed32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_fixed32_size += ::pb_jelly::wire_format::serialized_length(9);
-      optional_fixed32_size += l;
-    }
-    size += optional_fixed32_size;
-    let mut optional_sfixed64_size = 0;
-    if self.optional_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_sfixed64_size += ::pb_jelly::wire_format::serialized_length(10);
-      optional_sfixed64_size += l;
-    }
-    size += optional_sfixed64_size;
-    let mut optional_sfixed32_size = 0;
-    if self.optional_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.optional_sfixed32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_sfixed32_size += ::pb_jelly::wire_format::serialized_length(11);
-      optional_sfixed32_size += l;
-    }
-    size += optional_sfixed32_size;
-    let mut optional_double_size = 0;
-    if self.optional_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.optional_double;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_double_size += ::pb_jelly::wire_format::serialized_length(12);
-      optional_double_size += l;
-    }
-    size += optional_double_size;
-    let mut optional_bool_size = 0;
-    if self.optional_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.optional_bool;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_bool_size += ::pb_jelly::wire_format::serialized_length(13);
-      optional_bool_size += l;
-    }
-    size += optional_bool_size;
-    let mut optional_string_size = 0;
-    if self.optional_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.optional_string;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_string_size += ::pb_jelly::wire_format::serialized_length(14);
-      optional_string_size += ::pb_jelly::varint::serialized_length(l as u64);
-      optional_string_size += l;
-    }
-    size += optional_string_size;
-    let mut optional_bytes_size = 0;
-    if self.optional_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.optional_bytes;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_bytes_size += ::pb_jelly::wire_format::serialized_length(15);
-      optional_bytes_size += ::pb_jelly::varint::serialized_length(l as u64);
-      optional_bytes_size += l;
-    }
-    size += optional_bytes_size;
-    let mut optional_float_size = 0;
-    if self.optional_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.optional_float;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_float_size += ::pb_jelly::wire_format::serialized_length(16);
-      optional_float_size += l;
-    }
-    size += optional_float_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.optional_int32, 1, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<i64>(&self.optional_int64, 2, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<u32>(&self.optional_uint32, 3, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<u64>(&self.optional_uint64, 4, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Fixed64>(&self.optional_fixed64, 8, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Fixed32>(&self.optional_fixed32, 9, ::pb_jelly::wire_format::Type::Fixed32);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Sfixed64>(&self.optional_sfixed64, 10, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Sfixed32>(&self.optional_sfixed32, 11, ::pb_jelly::wire_format::Type::Fixed32);
+    size += ::pb_jelly::helpers::compute_size_scalar::<f64>(&self.optional_double, 12, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<bool>(&self.optional_bool, 13, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.optional_string, 14, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::vec::Vec<u8>>(&self.optional_bytes, 15, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<f32>(&self.optional_float, 16, ::pb_jelly::wire_format::Type::Fixed32);
     let mut optional_foreign_message_size = 0;
     for val in &self.optional_foreign_message {
       let l = ::pb_jelly::Message::compute_size(val);
@@ -3145,22 +2914,8 @@ impl ::pb_jelly::Message for TestMessage3 {
       optional_foreign_message_size += l;
     }
     size += optional_foreign_message_size;
-    let mut optional_nested_enum_size = 0;
-    if self.optional_nested_enum != <TestMessage3_NestedEnum3 as ::std::default::Default>::default() {
-      let val = &self.optional_nested_enum;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_nested_enum_size += ::pb_jelly::wire_format::serialized_length(21);
-      optional_nested_enum_size += l;
-    }
-    size += optional_nested_enum_size;
-    let mut optional_foreign_enum_size = 0;
-    if self.optional_foreign_enum != <ForeignEnum3 as ::std::default::Default>::default() {
-      let val = &self.optional_foreign_enum;
-      let l = ::pb_jelly::Message::compute_size(val);
-      optional_foreign_enum_size += ::pb_jelly::wire_format::serialized_length(22);
-      optional_foreign_enum_size += l;
-    }
-    size += optional_foreign_enum_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<TestMessage3_NestedEnum3>(&self.optional_nested_enum, 21, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<ForeignEnum3>(&self.optional_foreign_enum, 22, ::pb_jelly::wire_format::Type::Varint);
     let mut repeated_int32_size = 0;
     for val in &self.repeated_int32 {
       let l = ::pb_jelly::Message::compute_size(val);
@@ -3496,15 +3251,7 @@ impl ::pb_jelly::Message for TestMessage3 {
       nested_repeated_size += l;
     }
     size += nested_repeated_size;
-    let mut fixed_length_size = 0;
-    if self.fixed_length != <[u8; 4] as ::std::default::Default>::default() {
-      let val = &self.fixed_length;
-      let l = ::pb_jelly::Message::compute_size(val);
-      fixed_length_size += ::pb_jelly::wire_format::serialized_length(76);
-      fixed_length_size += ::pb_jelly::varint::serialized_length(l as u64);
-      fixed_length_size += l;
-    }
-    size += fixed_length_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<[u8; 4]>(&self.fixed_length, 76, ::pb_jelly::wire_format::Type::LengthDelimited);
     let mut fixed_length_repeated_size = 0;
     for val in &self.fixed_length_repeated {
       let l = ::pb_jelly::Message::compute_size(val);
@@ -3513,15 +3260,7 @@ impl ::pb_jelly::Message for TestMessage3 {
       fixed_length_repeated_size += l;
     }
     size += fixed_length_repeated_size;
-    let mut zero_or_fixed_length_size = 0;
-    if self.zero_or_fixed_length != <Option<[u8; 4]> as ::std::default::Default>::default() {
-      let val = &self.zero_or_fixed_length;
-      let l = ::pb_jelly::Message::compute_size(val);
-      zero_or_fixed_length_size += ::pb_jelly::wire_format::serialized_length(78);
-      zero_or_fixed_length_size += ::pb_jelly::varint::serialized_length(l as u64);
-      zero_or_fixed_length_size += l;
-    }
-    size += zero_or_fixed_length_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<Option<[u8; 4]>>(&self.zero_or_fixed_length, 78, ::pb_jelly::wire_format::Type::LengthDelimited);
     let mut zero_or_fixed_length_repeated_size = 0;
     for val in &self.zero_or_fixed_length_repeated {
       let l = ::pb_jelly::Message::compute_size(val);
@@ -5002,14 +4741,7 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage_File {
       blocklist_size += l;
     }
     size += blocklist_size;
-    let mut size_size = 0;
-    if self.size != <u32 as ::std::default::Default>::default() {
-      let val = &self.size;
-      let l = ::pb_jelly::Message::compute_size(val);
-      size_size += ::pb_jelly::wire_format::serialized_length(2);
-      size_size += l;
-    }
-    size += size_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<u32>(&self.size, 2, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -5313,14 +5045,7 @@ impl ::pb_jelly::Message for TestMessage3NonNullableOneof {
       b_size += l;
     }
     size += b_size;
-    let mut other_field_size = 0;
-    if self.other_field != <u64 as ::std::default::Default>::default() {
-      let val = &self.other_field;
-      let l = ::pb_jelly::Message::compute_size(val);
-      other_field_size += ::pb_jelly::wire_format::serialized_length(3);
-      other_field_size += l;
-    }
-    size += other_field_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<u64>(&self.other_field, 3, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -5816,14 +5541,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut value_size = 0;
-    if self.value != <TestMessage3ClosedEnum_ClosedEnum as ::std::default::Default>::default() {
-      let val = &self.value;
-      let l = ::pb_jelly::Message::compute_size(val);
-      value_size += ::pb_jelly::wire_format::serialized_length(1);
-      value_size += l;
-    }
-    size += value_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<TestMessage3ClosedEnum_ClosedEnum>(&self.value, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -5909,14 +5627,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum2 {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut value_size = 0;
-    if self.value != <TestMessage3ClosedEnum2_ClosedEnum as ::std::default::Default>::default() {
-      let val = &self.value;
-      let l = ::pb_jelly::Message::compute_size(val);
-      value_size += ::pb_jelly::wire_format::serialized_length(1);
-      value_size += l;
-    }
-    size += value_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<TestMessage3ClosedEnum2_ClosedEnum>(&self.value, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -6102,15 +5813,7 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage_InnerMessage {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut name_size = 0;
-    if self.name != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.name;
-      let l = ::pb_jelly::Message::compute_size(val);
-      name_size += ::pb_jelly::wire_format::serialized_length(1);
-      name_size += ::pb_jelly::varint::serialized_length(l as u64);
-      name_size += l;
-    }
-    size += name_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.name, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -6198,15 +5901,7 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized1 {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut string1_size = 0;
-    if self.string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.string1;
-      let l = ::pb_jelly::Message::compute_size(val);
-      string1_size += ::pb_jelly::wire_format::serialized_length(1);
-      string1_size += ::pb_jelly::varint::serialized_length(l as u64);
-      string1_size += l;
-    }
-    size += string1_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size += self._unrecognized.len();
     size
   }
@@ -6441,121 +6136,20 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized2 {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut a_string1_size = 0;
-    if self.a_string1 != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.a_string1;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_string1_size += ::pb_jelly::wire_format::serialized_length(1);
-      a_string1_size += ::pb_jelly::varint::serialized_length(l as u64);
-      a_string1_size += l;
-    }
-    size += a_string1_size;
-    let mut a_int32_size = 0;
-    if self.a_int32 != <i32 as ::std::default::Default>::default() {
-      let val = &self.a_int32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_int32_size += ::pb_jelly::wire_format::serialized_length(2);
-      a_int32_size += l;
-    }
-    size += a_int32_size;
-    let mut a_int64_size = 0;
-    if self.a_int64 != <i64 as ::std::default::Default>::default() {
-      let val = &self.a_int64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_int64_size += ::pb_jelly::wire_format::serialized_length(3);
-      a_int64_size += l;
-    }
-    size += a_int64_size;
-    let mut a_uint32_size = 0;
-    if self.a_uint32 != <u32 as ::std::default::Default>::default() {
-      let val = &self.a_uint32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_uint32_size += ::pb_jelly::wire_format::serialized_length(4);
-      a_uint32_size += l;
-    }
-    size += a_uint32_size;
-    let mut a_uint64_size = 0;
-    if self.a_uint64 != <u64 as ::std::default::Default>::default() {
-      let val = &self.a_uint64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_uint64_size += ::pb_jelly::wire_format::serialized_length(5);
-      a_uint64_size += l;
-    }
-    size += a_uint64_size;
-    let mut a_fixed64_size = 0;
-    if self.a_fixed64 != <::pb_jelly::Fixed64 as ::std::default::Default>::default() {
-      let val = &self.a_fixed64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_fixed64_size += ::pb_jelly::wire_format::serialized_length(6);
-      a_fixed64_size += l;
-    }
-    size += a_fixed64_size;
-    let mut a_fixed32_size = 0;
-    if self.a_fixed32 != <::pb_jelly::Fixed32 as ::std::default::Default>::default() {
-      let val = &self.a_fixed32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_fixed32_size += ::pb_jelly::wire_format::serialized_length(7);
-      a_fixed32_size += l;
-    }
-    size += a_fixed32_size;
-    let mut a_sfixed64_size = 0;
-    if self.a_sfixed64 != <::pb_jelly::Sfixed64 as ::std::default::Default>::default() {
-      let val = &self.a_sfixed64;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_sfixed64_size += ::pb_jelly::wire_format::serialized_length(8);
-      a_sfixed64_size += l;
-    }
-    size += a_sfixed64_size;
-    let mut a_sfixed32_size = 0;
-    if self.a_sfixed32 != <::pb_jelly::Sfixed32 as ::std::default::Default>::default() {
-      let val = &self.a_sfixed32;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_sfixed32_size += ::pb_jelly::wire_format::serialized_length(9);
-      a_sfixed32_size += l;
-    }
-    size += a_sfixed32_size;
-    let mut a_double_size = 0;
-    if self.a_double != <f64 as ::std::default::Default>::default() {
-      let val = &self.a_double;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_double_size += ::pb_jelly::wire_format::serialized_length(10);
-      a_double_size += l;
-    }
-    size += a_double_size;
-    let mut a_bool_size = 0;
-    if self.a_bool != <bool as ::std::default::Default>::default() {
-      let val = &self.a_bool;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_bool_size += ::pb_jelly::wire_format::serialized_length(11);
-      a_bool_size += l;
-    }
-    size += a_bool_size;
-    let mut a_string_size = 0;
-    if self.a_string != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.a_string;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_string_size += ::pb_jelly::wire_format::serialized_length(12);
-      a_string_size += ::pb_jelly::varint::serialized_length(l as u64);
-      a_string_size += l;
-    }
-    size += a_string_size;
-    let mut a_bytes_size = 0;
-    if self.a_bytes != <::std::vec::Vec<u8> as ::std::default::Default>::default() {
-      let val = &self.a_bytes;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_bytes_size += ::pb_jelly::wire_format::serialized_length(13);
-      a_bytes_size += ::pb_jelly::varint::serialized_length(l as u64);
-      a_bytes_size += l;
-    }
-    size += a_bytes_size;
-    let mut a_float_size = 0;
-    if self.a_float != <f32 as ::std::default::Default>::default() {
-      let val = &self.a_float;
-      let l = ::pb_jelly::Message::compute_size(val);
-      a_float_size += ::pb_jelly::wire_format::serialized_length(14);
-      a_float_size += l;
-    }
-    size += a_float_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.a_string1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.a_int32, 2, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<i64>(&self.a_int64, 3, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<u32>(&self.a_uint32, 4, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<u64>(&self.a_uint64, 5, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Fixed64>(&self.a_fixed64, 6, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Fixed32>(&self.a_fixed32, 7, ::pb_jelly::wire_format::Type::Fixed32);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Sfixed64>(&self.a_sfixed64, 8, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Sfixed32>(&self.a_sfixed32, 9, ::pb_jelly::wire_format::Type::Fixed32);
+    size += ::pb_jelly::helpers::compute_size_scalar::<f64>(&self.a_double, 10, ::pb_jelly::wire_format::Type::Fixed64);
+    size += ::pb_jelly::helpers::compute_size_scalar::<bool>(&self.a_bool, 11, ::pb_jelly::wire_format::Type::Varint);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.a_string, 12, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::vec::Vec<u8>>(&self.a_bytes, 13, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<f32>(&self.a_float, 14, ::pb_jelly::wire_format::Type::Fixed32);
     size += self._unrecognized.len();
     size
   }
@@ -6868,15 +6462,7 @@ impl ::pb_jelly::Message for TestSmallString {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut compact_size = 0;
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      let l = ::pb_jelly::Message::compute_size(val);
-      compact_size += ::pb_jelly::wire_format::serialized_length(1);
-      compact_size += ::pb_jelly::varint::serialized_length(l as u64);
-      compact_size += l;
-    }
-    size += compact_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -6962,15 +6548,7 @@ impl ::pb_jelly::Message for TestBoxedSmallString {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut compact_size = 0;
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      let l = ::pb_jelly::Message::compute_size(val);
-      compact_size += ::pb_jelly::wire_format::serialized_length(1);
-      compact_size += ::pb_jelly::varint::serialized_length(l as u64);
-      compact_size += l;
-    }
-    size += compact_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -7056,15 +6634,7 @@ impl ::pb_jelly::Message for TestNonOptionalSmallString {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut compact_size = 0;
-    if self.compact != <::compact_str::CompactString as ::std::default::Default>::default() {
-      let val = &self.compact;
-      let l = ::pb_jelly::Message::compute_size(val);
-      compact_size += ::pb_jelly::wire_format::serialized_length(1);
-      compact_size += ::pb_jelly::varint::serialized_length(l as u64);
-      compact_size += l;
-    }
-    size += compact_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::compact_str::CompactString>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -7152,15 +6722,7 @@ impl ::pb_jelly::Message for TestSmallStringPreserveUnrecognized {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut compact_size = 0;
-    if self.compact != <::std::string::String as ::std::default::Default>::default() {
-      let val = &self.compact;
-      let l = ::pb_jelly::Message::compute_size(val);
-      compact_size += ::pb_jelly::wire_format::serialized_length(1);
-      compact_size += ::pb_jelly::varint::serialized_length(l as u64);
-      compact_size += l;
-    }
-    size += compact_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::std::string::String>(&self.compact, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
     size += self._unrecognized.len();
     size
   }
@@ -7992,24 +7554,8 @@ impl ::pb_jelly::Message for TestProto3Zerocopy {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut data1_size = 0;
-    if self.data1 != <::pb_jelly::Lazy<::bytes::Bytes> as ::std::default::Default>::default() {
-      let val = &self.data1;
-      let l = ::pb_jelly::Message::compute_size(val);
-      data1_size += ::pb_jelly::wire_format::serialized_length(1);
-      data1_size += ::pb_jelly::varint::serialized_length(l as u64);
-      data1_size += l;
-    }
-    size += data1_size;
-    let mut data2_size = 0;
-    if self.data2 != <::pb_jelly::Lazy<::bytes::Bytes> as ::std::default::Default>::default() {
-      let val = &self.data2;
-      let l = ::pb_jelly::Message::compute_size(val);
-      data2_size += ::pb_jelly::wire_format::serialized_length(2);
-      data2_size += ::pb_jelly::varint::serialized_length(l as u64);
-      data2_size += l;
-    }
-    size += data2_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Lazy<::bytes::Bytes>>(&self.data1, 1, ::pb_jelly::wire_format::Type::LengthDelimited);
+    size += ::pb_jelly::helpers::compute_size_scalar::<::pb_jelly::Lazy<::bytes::Bytes>>(&self.data2, 2, ::pb_jelly::wire_format::Type::LengthDelimited);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -10,14 +10,6 @@ impl ForeignEnum3 {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<ForeignEnum3_Closed> {
-    match self {
-      ForeignEnum3::FOREIGN3_FOO => Some(ForeignEnum3_Closed::FOREIGN3_FOO),
-      ForeignEnum3::FOREIGN3_BAR => Some(ForeignEnum3_Closed::FOREIGN3_BAR),
-      ForeignEnum3::FOREIGN3_BAZ => Some(ForeignEnum3_Closed::FOREIGN3_BAZ),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for ForeignEnum3 {
   fn default() -> Self {
@@ -42,27 +34,19 @@ impl From<ForeignEnum3_Closed> for ForeignEnum3 {
 impl ::pb_jelly::ProtoEnum for ForeignEnum3 {
 }
 impl ::pb_jelly::OpenProtoEnum for ForeignEnum3 {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = ForeignEnum3_Closed;
+  fn into_known(self) -> ::std::option::Option<ForeignEnum3_Closed> {
     match self {
-      ForeignEnum3::FOREIGN3_FOO => Some("FOREIGN3_FOO"),
-      ForeignEnum3::FOREIGN3_BAR => Some("FOREIGN3_BAR"),
-      ForeignEnum3::FOREIGN3_BAZ => Some("FOREIGN3_BAZ"),
+      ForeignEnum3::FOREIGN3_FOO => Some(ForeignEnum3_Closed::FOREIGN3_FOO),
+      ForeignEnum3::FOREIGN3_BAR => Some(ForeignEnum3_Closed::FOREIGN3_BAR),
+      ForeignEnum3::FOREIGN3_BAZ => Some(ForeignEnum3_Closed::FOREIGN3_BAZ),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      ForeignEnum3::FOREIGN3_FOO => true,
-      ForeignEnum3::FOREIGN3_BAR => true,
-      ForeignEnum3::FOREIGN3_BAZ => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for ForeignEnum3 {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }
@@ -124,12 +108,6 @@ impl Version31Enum_TestEnum {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<Version31Enum_TestEnum_Closed> {
-    match self {
-      Version31Enum_TestEnum::ENUM0 => Some(Version31Enum_TestEnum_Closed::ENUM0),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for Version31Enum_TestEnum {
   fn default() -> Self {
@@ -154,23 +132,17 @@ impl From<Version31Enum_TestEnum_Closed> for Version31Enum_TestEnum {
 impl ::pb_jelly::ProtoEnum for Version31Enum_TestEnum {
 }
 impl ::pb_jelly::OpenProtoEnum for Version31Enum_TestEnum {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = Version31Enum_TestEnum_Closed;
+  fn into_known(self) -> ::std::option::Option<Version31Enum_TestEnum_Closed> {
     match self {
-      Version31Enum_TestEnum::ENUM0 => Some("ENUM0"),
+      Version31Enum_TestEnum::ENUM0 => Some(Version31Enum_TestEnum_Closed::ENUM0),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      Version31Enum_TestEnum::ENUM0 => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for Version31Enum_TestEnum {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }
@@ -225,13 +197,6 @@ impl Version32Enum_TestEnum {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<Version32Enum_TestEnum_Closed> {
-    match self {
-      Version32Enum_TestEnum::ENUM0 => Some(Version32Enum_TestEnum_Closed::ENUM0),
-      Version32Enum_TestEnum::ENUM1 => Some(Version32Enum_TestEnum_Closed::ENUM1),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for Version32Enum_TestEnum {
   fn default() -> Self {
@@ -256,25 +221,18 @@ impl From<Version32Enum_TestEnum_Closed> for Version32Enum_TestEnum {
 impl ::pb_jelly::ProtoEnum for Version32Enum_TestEnum {
 }
 impl ::pb_jelly::OpenProtoEnum for Version32Enum_TestEnum {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = Version32Enum_TestEnum_Closed;
+  fn into_known(self) -> ::std::option::Option<Version32Enum_TestEnum_Closed> {
     match self {
-      Version32Enum_TestEnum::ENUM0 => Some("ENUM0"),
-      Version32Enum_TestEnum::ENUM1 => Some("ENUM1"),
+      Version32Enum_TestEnum::ENUM0 => Some(Version32Enum_TestEnum_Closed::ENUM0),
+      Version32Enum_TestEnum::ENUM1 => Some(Version32Enum_TestEnum_Closed::ENUM1),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      Version32Enum_TestEnum::ENUM0 => true,
-      Version32Enum_TestEnum::ENUM1 => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for Version32Enum_TestEnum {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }
@@ -336,15 +294,6 @@ impl TestMessage3_NestedEnum3 {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<TestMessage3_NestedEnum3_Closed> {
-    match self {
-      TestMessage3_NestedEnum3::FOO => Some(TestMessage3_NestedEnum3_Closed::FOO),
-      TestMessage3_NestedEnum3::BAR => Some(TestMessage3_NestedEnum3_Closed::BAR),
-      TestMessage3_NestedEnum3::BAZ => Some(TestMessage3_NestedEnum3_Closed::BAZ),
-      TestMessage3_NestedEnum3::NEG => Some(TestMessage3_NestedEnum3_Closed::NEG),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for TestMessage3_NestedEnum3 {
   fn default() -> Self {
@@ -369,29 +318,20 @@ impl From<TestMessage3_NestedEnum3_Closed> for TestMessage3_NestedEnum3 {
 impl ::pb_jelly::ProtoEnum for TestMessage3_NestedEnum3 {
 }
 impl ::pb_jelly::OpenProtoEnum for TestMessage3_NestedEnum3 {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = TestMessage3_NestedEnum3_Closed;
+  fn into_known(self) -> ::std::option::Option<TestMessage3_NestedEnum3_Closed> {
     match self {
-      TestMessage3_NestedEnum3::FOO => Some("FOO"),
-      TestMessage3_NestedEnum3::BAR => Some("BAR"),
-      TestMessage3_NestedEnum3::BAZ => Some("BAZ"),
-      TestMessage3_NestedEnum3::NEG => Some("NEG"),
+      TestMessage3_NestedEnum3::FOO => Some(TestMessage3_NestedEnum3_Closed::FOO),
+      TestMessage3_NestedEnum3::BAR => Some(TestMessage3_NestedEnum3_Closed::BAR),
+      TestMessage3_NestedEnum3::BAZ => Some(TestMessage3_NestedEnum3_Closed::BAZ),
+      TestMessage3_NestedEnum3::NEG => Some(TestMessage3_NestedEnum3_Closed::NEG),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      TestMessage3_NestedEnum3::FOO => true,
-      TestMessage3_NestedEnum3::BAR => true,
-      TestMessage3_NestedEnum3::BAZ => true,
-      TestMessage3_NestedEnum3::NEG => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for TestMessage3_NestedEnum3 {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }
@@ -458,12 +398,6 @@ impl TestMessage3_NestedMessage_Enum {
   pub const fn value(self) -> i32 {
     self.0
   }
-  pub fn into_known(self) -> ::std::option::Option<TestMessage3_NestedMessage_Enum_Closed> {
-    match self {
-      TestMessage3_NestedMessage_Enum::ENUM_VARIANT_ONE => Some(TestMessage3_NestedMessage_Enum_Closed::ENUM_VARIANT_ONE),
-      _ => None,
-    }
-  }
 }
 impl ::std::default::Default for TestMessage3_NestedMessage_Enum {
   fn default() -> Self {
@@ -488,23 +422,17 @@ impl From<TestMessage3_NestedMessage_Enum_Closed> for TestMessage3_NestedMessage
 impl ::pb_jelly::ProtoEnum for TestMessage3_NestedMessage_Enum {
 }
 impl ::pb_jelly::OpenProtoEnum for TestMessage3_NestedMessage_Enum {
-  fn name(self) -> ::std::option::Option<&'static str> {
+  type Closed = TestMessage3_NestedMessage_Enum_Closed;
+  fn into_known(self) -> ::std::option::Option<TestMessage3_NestedMessage_Enum_Closed> {
     match self {
-      TestMessage3_NestedMessage_Enum::ENUM_VARIANT_ONE => Some("ENUM_VARIANT_ONE"),
+      TestMessage3_NestedMessage_Enum::ENUM_VARIANT_ONE => Some(TestMessage3_NestedMessage_Enum_Closed::ENUM_VARIANT_ONE),
       _ => None,
-    }
-  }
-  fn is_known(self) -> bool {
-    match self {
-      TestMessage3_NestedMessage_Enum::ENUM_VARIANT_ONE => true,
-      _ => false,
     }
   }
 }
 impl ::std::fmt::Debug for TestMessage3_NestedMessage_Enum {
   fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-    use ::pb_jelly::OpenProtoEnum;
-    match self.name() {
+    match <Self as ::pb_jelly::OpenProtoEnum>::name(*self) {
       Some(s) => write!(f, "{}", s),
       None => write!(f, "Unknown({})", self.0),
     }

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -822,9 +822,7 @@ impl ::pb_jelly::Message for ForeignMessage3 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "ForeignMessage3", 1)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "ForeignMessage3", 1)?;
           self.c = val;
         }
         _ => {
@@ -956,19 +954,11 @@ impl ::pb_jelly::Message for Version31OneOfNoneNullable {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version31OneOfNoneNullable", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version31OneOfNoneNullable", 1)?;
           oneof_test_oneof = Some(Version31OneOfNoneNullable_TestOneof::StringOneOf(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version31OneOfNoneNullable", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version31OneOfNoneNullable", 2)?;
           oneof_test_oneof = Some(Version31OneOfNoneNullable_TestOneof::StringTwoOf(val));
         }
         _ => {
@@ -1158,25 +1148,15 @@ impl ::pb_jelly::Message for Version32OneOfNoneNullable {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version32OneOfNoneNullable", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version32OneOfNoneNullable", 1)?;
           oneof_test_oneof = Some(Version32OneOfNoneNullable_TestOneof::StringOneOf(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version32OneOfNoneNullable", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version32OneOfNoneNullable", 2)?;
           oneof_test_oneof = Some(Version32OneOfNoneNullable_TestOneof::StringTwoOf(val));
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32OneOfNoneNullable", 3)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32OneOfNoneNullable", 3)?;
           oneof_test_oneof = Some(Version32OneOfNoneNullable_TestOneof::IntOneOf(val));
         }
         _ => {
@@ -1322,9 +1302,7 @@ impl ::pb_jelly::Message for Version31Enum {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version31Enum", 1)?;
-          let mut val: Version31Enum_TestEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, Version31Enum_TestEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version31Enum", 1)?;
           self.enum_field = val;
         }
         _ => {
@@ -1421,9 +1399,7 @@ impl ::pb_jelly::Message for Version32Enum {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32Enum", 1)?;
-          let mut val: Version32Enum_TestEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, Version32Enum_TestEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32Enum", 1)?;
           self.enum_field = val;
         }
         _ => {
@@ -1527,11 +1503,7 @@ impl ::pb_jelly::Message for Version31OneOf {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version31OneOf", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version31OneOf", 1)?;
           self.test_oneof = Some(Version31OneOf_TestOneof::StringOneOf(val));
         }
         _ => {
@@ -1674,17 +1646,11 @@ impl ::pb_jelly::Message for Version32OneOf {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version32OneOf", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version32OneOf", 1)?;
           self.test_oneof = Some(Version32OneOf_TestOneof::StringOneOf(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32OneOf", 2)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32OneOf", 2)?;
           self.test_oneof = Some(Version32OneOf_TestOneof::IntOneOf(val));
         }
         _ => {
@@ -1814,11 +1780,7 @@ impl ::pb_jelly::Message for Version31 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version31", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version31", 1)?;
           self.optional_string1 = val;
         }
         _ => {
@@ -1918,11 +1880,7 @@ impl ::pb_jelly::Message for Version31SSO {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version31SSO", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "Version31SSO", 1)?;
           self.optional_string1 = val;
         }
         _ => {
@@ -2392,93 +2350,59 @@ impl ::pb_jelly::Message for Version32 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version32", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version32", 1)?;
           self.optional_string1 = val;
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 2)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 2)?;
           self.optional_int32 = val;
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 3)?;
-          let mut val: i64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 3)?;
           self.optional_int64 = val;
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 4)?;
-          let mut val: u32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 4)?;
           self.optional_uint32 = val;
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 5)?;
-          let mut val: u64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 5)?;
           self.optional_uint64 = val;
         }
         6 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "Version32", 6)?;
-          let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "Version32", 6)?;
           self.optional_fixed64 = val;
         }
         7 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "Version32", 7)?;
-          let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "Version32", 7)?;
           self.optional_fixed32 = val;
         }
         8 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "Version32", 8)?;
-          let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "Version32", 8)?;
           self.optional_sfixed64 = val;
         }
         9 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "Version32", 9)?;
-          let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "Version32", 9)?;
           self.optional_sfixed32 = val;
         }
         10 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "Version32", 10)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "Version32", 10)?;
           self.optional_double = val;
         }
         11 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 11)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Version32", 11)?;
           self.optional_bool = val;
         }
         12 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version32", 12)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "Version32", 12)?;
           self.optional_string = val;
         }
         13 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Version32", 13)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "Version32", 13)?;
           self.optional_bytes = val;
         }
         14 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "Version32", 14)?;
-          let mut val: f32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "Version32", 14)?;
           self.optional_float = val;
         }
         _ => {
@@ -4376,576 +4300,226 @@ impl ::pb_jelly::Message for TestMessage3 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 1)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 1)?;
           self.optional_int32 = val;
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 2)?;
-          let mut val: i64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 2)?;
           self.optional_int64 = val;
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 3)?;
-          let mut val: u32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 3)?;
           self.optional_uint32 = val;
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 4)?;
-          let mut val: u64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 4)?;
           self.optional_uint64 = val;
         }
         8 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 8)?;
-          let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 8)?;
           self.optional_fixed64 = val;
         }
         9 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 9)?;
-          let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 9)?;
           self.optional_fixed32 = val;
         }
         10 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 10)?;
-          let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 10)?;
           self.optional_sfixed64 = val;
         }
         11 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 11)?;
-          let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 11)?;
           self.optional_sfixed32 = val;
         }
         12 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 12)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 12)?;
           self.optional_double = val;
         }
         13 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 13)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 13)?;
           self.optional_bool = val;
         }
         14 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 14)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestMessage3", 14)?;
           self.optional_string = val;
         }
         15 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 15)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "TestMessage3", 15)?;
           self.optional_bytes = val;
         }
         16 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 16)?;
-          let mut val: f32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 16)?;
           self.optional_float = val;
         }
         19 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 19)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 19)?;
           self.optional_foreign_message = Some(val);
         }
         21 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 21)?;
-          let mut val: TestMessage3_NestedEnum3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3_NestedEnum3>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 21)?;
           self.optional_nested_enum = val;
         }
         22 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 22)?;
-          let mut val: ForeignEnum3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ForeignEnum3>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 22)?;
           self.optional_foreign_enum = val;
         }
         31 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: i32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_int32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 31)?;
-              let mut val: i32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_int32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 31, &mut self.repeated_int32)?;
         }
         32 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: i64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_int64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 32)?;
-              let mut val: i64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_int64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 32, &mut self.repeated_int64)?;
         }
         33 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: u32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_uint32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 33)?;
-              let mut val: u32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_uint32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 33, &mut self.repeated_uint32)?;
         }
         34 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: u64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_uint64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 34)?;
-              let mut val: u64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_uint64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 34, &mut self.repeated_uint64)?;
         }
         38 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_fixed64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 38)?;
-              let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_fixed64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 38, &mut self.repeated_fixed64)?;
         }
         39 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_fixed32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 39)?;
-              let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_fixed32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 39, &mut self.repeated_fixed32)?;
         }
         40 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_sfixed64.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 40)?;
-              let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_sfixed64.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 40, &mut self.repeated_sfixed64)?;
         }
         41 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_sfixed32.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 41)?;
-              let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_sfixed32.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 41, &mut self.repeated_sfixed32)?;
         }
         42 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: f64 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_double.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 42)?;
-              let mut val: f64 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_double.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestMessage3", 42, &mut self.repeated_double)?;
         }
         43 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: bool = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_bool.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 43)?;
-              let mut val: bool = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_bool.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 43, &mut self.repeated_bool)?;
         }
         44 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 44)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestMessage3", 44)?;
           self.repeated_string.push(val);
         }
         45 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 45)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "TestMessage3", 45)?;
           self.repeated_bytes.push(val);
         }
         46 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: f32 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_float.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 46)?;
-              let mut val: f32 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_float.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestMessage3", 46, &mut self.repeated_float)?;
         }
         49 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 49)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 49)?;
           self.repeated_foreign_message.push(val);
         }
         51 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: TestMessage3_NestedEnum3 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_nested_enum.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 51)?;
-              let mut val: TestMessage3_NestedEnum3 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_nested_enum.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, TestMessage3_NestedEnum3>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 51, &mut self.repeated_nested_enum)?;
         }
         52 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: ForeignEnum3 = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.repeated_foreign_enum.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 52)?;
-              let mut val: ForeignEnum3 = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.repeated_foreign_enum.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, ForeignEnum3>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 52, &mut self.repeated_foreign_enum)?;
         }
         53 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 53)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: super::pbtest2::ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, super::pbtest2::ForeignMessage>(buf, typ, "TestMessage3", 53)?;
           self.proto2_msg = Some(val);
         }
         54 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 54)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: super::pbtest2::ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, super::pbtest2::ForeignMessage>(buf, typ, "TestMessage3", 54)?;
           self.proto2_msg_empty = Some(val);
         }
         55 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 55)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: super::pbtest2::ForeignMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, super::pbtest2::ForeignMessage>(buf, typ, "TestMessage3", 55)?;
           self.proto2_msg_missing = Some(val);
         }
         56 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 56)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 56)?;
           self.optional_foreign_message_boxed = Some(Box::new(val));
         }
         69 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 69)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 69)?;
           self.optional_foreign_message_nonnullable = val;
         }
         57 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 57)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 57)?;
           self.oneof_int = Some(TestMessage3_OneofInt::Int1(val));
         }
         58 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 58)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 58)?;
           self.oneof_int = Some(TestMessage3_OneofInt::Foreign1(val));
         }
         59 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 59)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 59)?;
           self.oneof_foreign = Some(TestMessage3_OneofForeign::Int2(val));
         }
         60 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 60)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 60)?;
           self.oneof_foreign = Some(TestMessage3_OneofForeign::Foreign2(val));
         }
         61 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 61)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 61)?;
           self.oneof_zero = Some(TestMessage3_OneofZero::Int3(val));
         }
         62 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 62)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 62)?;
           self.oneof_zero = Some(TestMessage3_OneofZero::Foreign3(val));
         }
         63 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 63)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 63)?;
           self.oneof_null = Some(TestMessage3_OneofNull::Int4(val));
         }
         64 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 64)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 64)?;
           self.oneof_null = Some(TestMessage3_OneofNull::Foreign4(val));
         }
         65 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 65)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 65)?;
           self.oneof_unset = Some(TestMessage3_OneofUnset::Int5(val));
         }
         66 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 66)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestMessage3", 66)?;
           self.oneof_unset = Some(TestMessage3_OneofUnset::Foreign5(val));
         }
         67 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 67)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 67)?;
           self.oneof_primitives = Some(TestMessage3_OneofPrimitives::Int6(val));
         }
         68 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 68)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 68)?;
           self.oneof_primitives = Some(TestMessage3_OneofPrimitives::Bool6(val));
         }
         70 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 70)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::proto_google::protobuf::empty::Empty = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::proto_google::protobuf::empty::Empty>(buf, typ, "TestMessage3", 70)?;
           oneof_oneof_empty_field = Some(TestMessage3_OneofEmptyField::A);
         }
         71 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 71)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::proto_google::protobuf::empty::Empty = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::proto_google::protobuf::empty::Empty>(buf, typ, "TestMessage3", 71)?;
           oneof_oneof_empty_field = Some(TestMessage3_OneofEmptyField::B);
         }
         72 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 72)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3", 72)?;
           oneof_oneof_empty_field = Some(TestMessage3_OneofEmptyField::C(val));
         }
         73 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 73)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: TestMessage3_NestedMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, TestMessage3_NestedMessage>(buf, typ, "TestMessage3", 73)?;
           self.nested = val;
         }
         74 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 74)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: TestMessage3_NestedMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, TestMessage3_NestedMessage>(buf, typ, "TestMessage3", 74)?;
           self.nested_nullable = Some(val);
         }
         75 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 75)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: TestMessage3_NestedMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, TestMessage3_NestedMessage>(buf, typ, "TestMessage3", 75)?;
           self.nested_repeated.push(val);
         }
         76 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 76)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: [u8; 4] = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, [u8; 4]>(buf, typ, "TestMessage3", 76)?;
           self.fixed_length = val;
         }
         77 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 77)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: [u8; 4] = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, [u8; 4]>(buf, typ, "TestMessage3", 77)?;
           self.fixed_length_repeated.push(val);
         }
         78 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 78)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: Option<[u8; 4]> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, Option<[u8; 4]>>(buf, typ, "TestMessage3", 78)?;
           self.zero_or_fixed_length = val;
         }
         79 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3", 79)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: Option<[u8; 4]> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, Option<[u8; 4]>>(buf, typ, "TestMessage3", 79)?;
           self.zero_or_fixed_length_repeated.push(val);
         }
         _ => {
@@ -5500,31 +5074,19 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3_NestedMessage", 3)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: TestMessage3_NestedMessage_File = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, TestMessage3_NestedMessage_File>(buf, typ, "TestMessage3_NestedMessage", 3)?;
           oneof_nested_oneof = Some(TestMessage3_NestedMessage_NestedOneof::F(val));
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3_NestedMessage", 4)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: TestMessage3_NestedMessage_Dir = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, TestMessage3_NestedMessage_Dir>(buf, typ, "TestMessage3_NestedMessage", 4)?;
           oneof_nested_oneof = Some(TestMessage3_NestedMessage_NestedOneof::D(val));
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3_NestedMessage", 5)?;
-          let mut val: TestMessage3_NestedMessage_Enum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3_NestedMessage_Enum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3_NestedMessage", 5)?;
           oneof_nested_oneof = Some(TestMessage3_NestedMessage_NestedOneof::E(val));
         }
         6 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3_NestedMessage", 6)?;
-          let mut val: TestMessage3_NestedMessage_NonNullableEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3_NestedMessage_NonNullableEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3_NestedMessage", 6)?;
           oneof_nested_oneof = Some(TestMessage3_NestedMessage_NestedOneof::N(val));
         }
         _ => {
@@ -5713,17 +5275,11 @@ impl ::pb_jelly::Message for TestMessage3_NestedMessage_File {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3_NestedMessage_File", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "TestMessage3_NestedMessage_File", 1)?;
           self.blocklist.push(val);
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3_NestedMessage_File", 2)?;
-          let mut val: u32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3_NestedMessage_File", 2)?;
           self.size = val;
         }
         _ => {
@@ -5886,11 +5442,7 @@ impl ::pb_jelly::Message for TestBoxedNonnullable {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestBoxedNonnullable", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestBoxedNonnullable", 1)?;
           self.field = Box::new(val);
         }
         _ => {
@@ -6044,21 +5596,15 @@ impl ::pb_jelly::Message for TestMessage3NonNullableOneof {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3NonNullableOneof", 1)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3NonNullableOneof", 1)?;
           oneof_non_nullable_oneof = Some(TestMessage3NonNullableOneof_NonNullableOneof::A(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3NonNullableOneof", 2)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3NonNullableOneof", 2)?;
           oneof_non_nullable_oneof = Some(TestMessage3NonNullableOneof_NonNullableOneof::B(val));
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3NonNullableOneof", 3)?;
-          let mut val: u64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3NonNullableOneof", 3)?;
           self.other_field = val;
         }
         _ => {
@@ -6187,9 +5733,7 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnum {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ErrIfDefaultEnum", 1)?;
-          let mut val: TestMessage3ErrIfDefaultEnum_ErrIfDefaultEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3ErrIfDefaultEnum_ErrIfDefaultEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ErrIfDefaultEnum", 1)?;
           field = Some(val);
         }
         _ => {
@@ -6322,17 +5866,11 @@ impl ::pb_jelly::Message for TestMessage3ErrIfDefaultEnumOneof {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ErrIfDefaultEnumOneof", 1)?;
-          let mut val: TestMessage3ErrIfDefaultEnumOneof_ErrIfDefaultEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3ErrIfDefaultEnumOneof_ErrIfDefaultEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ErrIfDefaultEnumOneof", 1)?;
           self.maybe = Some(TestMessage3ErrIfDefaultEnumOneof_Maybe::Something(val));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3ErrIfDefaultEnumOneof", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::proto_google::protobuf::empty::Empty = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::proto_google::protobuf::empty::Empty>(buf, typ, "TestMessage3ErrIfDefaultEnumOneof", 2)?;
           self.nothing = Some(val);
         }
         _ => {
@@ -6454,23 +5992,7 @@ impl ::pb_jelly::Message for TestMessage3RepeatedErrIfDefaultEnum {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          match typ {
-            ::pb_jelly::wire_format::Type::LengthDelimited => {
-              let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-              let mut vals = ::pb_jelly::ensure_split(buf, len as usize)?;
-              while vals.has_remaining() {
-                let mut val: TestMessage3ErrIfDefaultEnum_ErrIfDefaultEnum = ::std::default::Default::default();
-                ::pb_jelly::Message::deserialize(&mut val, &mut vals)?;
-                self.field.push(val);
-              }
-            }
-            _ => {
-              ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3RepeatedErrIfDefaultEnum", 1)?;
-              let mut val: TestMessage3ErrIfDefaultEnum_ErrIfDefaultEnum = ::std::default::Default::default();
-              ::pb_jelly::Message::deserialize(&mut val, buf)?;
-              self.field.push(val);
-            }
-          }
+          ::pb_jelly::helpers::deserialize_packed::<B, TestMessage3ErrIfDefaultEnum_ErrIfDefaultEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3RepeatedErrIfDefaultEnum", 1, &mut self.field)?;
         }
         _ => {
           ::pb_jelly::skip(typ, &mut buf)?;
@@ -6566,9 +6088,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ClosedEnum", 1)?;
-          let mut val: TestMessage3ClosedEnum_ClosedEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3ClosedEnum_ClosedEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ClosedEnum", 1)?;
           self.value = val;
         }
         _ => {
@@ -6665,9 +6185,7 @@ impl ::pb_jelly::Message for TestMessage3ClosedEnum2 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ClosedEnum2", 1)?;
-          let mut val: TestMessage3ClosedEnum2_ClosedEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3ClosedEnum2_ClosedEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestMessage3ClosedEnum2", 1)?;
           self.value = val;
         }
         _ => {
@@ -6767,11 +6285,7 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3NonOptionalBoxedMessage", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: TestMessage3NonOptionalBoxedMessage_InnerMessage = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, TestMessage3NonOptionalBoxedMessage_InnerMessage>(buf, typ, "TestMessage3NonOptionalBoxedMessage", 1)?;
           self.msg = Box::new(val);
         }
         _ => {
@@ -6871,11 +6385,7 @@ impl ::pb_jelly::Message for TestMessage3NonOptionalBoxedMessage_InnerMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestMessage3NonOptionalBoxedMessage_InnerMessage", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestMessage3NonOptionalBoxedMessage_InnerMessage", 1)?;
           self.name = val;
         }
         _ => {
@@ -6980,11 +6490,7 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized1 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestPreserveUnrecognized1", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestPreserveUnrecognized1", 1)?;
           self.string1 = val;
         }
         _ => {
@@ -7460,93 +6966,59 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized2 {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestPreserveUnrecognized2", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestPreserveUnrecognized2", 1)?;
           self.a_string1 = val;
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 2)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 2)?;
           self.a_int32 = val;
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 3)?;
-          let mut val: i64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 3)?;
           self.a_int64 = val;
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 4)?;
-          let mut val: u32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 4)?;
           self.a_uint32 = val;
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 5)?;
-          let mut val: u64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 5)?;
           self.a_uint64 = val;
         }
         6 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestPreserveUnrecognized2", 6)?;
-          let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestPreserveUnrecognized2", 6)?;
           self.a_fixed64 = val;
         }
         7 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestPreserveUnrecognized2", 7)?;
-          let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestPreserveUnrecognized2", 7)?;
           self.a_fixed32 = val;
         }
         8 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestPreserveUnrecognized2", 8)?;
-          let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestPreserveUnrecognized2", 8)?;
           self.a_sfixed64 = val;
         }
         9 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestPreserveUnrecognized2", 9)?;
-          let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestPreserveUnrecognized2", 9)?;
           self.a_sfixed32 = val;
         }
         10 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestPreserveUnrecognized2", 10)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestPreserveUnrecognized2", 10)?;
           self.a_double = val;
         }
         11 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 11)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestPreserveUnrecognized2", 11)?;
           self.a_bool = val;
         }
         12 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestPreserveUnrecognized2", 12)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestPreserveUnrecognized2", 12)?;
           self.a_string = val;
         }
         13 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestPreserveUnrecognized2", 13)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "TestPreserveUnrecognized2", 13)?;
           self.a_bytes = val;
         }
         14 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestPreserveUnrecognized2", 14)?;
-          let mut val: f32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestPreserveUnrecognized2", 14)?;
           self.a_float = val;
         }
         _ => {
@@ -7753,11 +7225,7 @@ impl ::pb_jelly::Message for TestSmallString {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestSmallString", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "TestSmallString", 1)?;
           self.compact = val;
         }
         _ => {
@@ -7857,11 +7325,7 @@ impl ::pb_jelly::Message for TestBoxedSmallString {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestBoxedSmallString", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "TestBoxedSmallString", 1)?;
           self.compact = val;
         }
         _ => {
@@ -7961,11 +7425,7 @@ impl ::pb_jelly::Message for TestNonOptionalSmallString {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestNonOptionalSmallString", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::compact_str::CompactString = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::compact_str::CompactString>(buf, typ, "TestNonOptionalSmallString", 1)?;
           self.compact = val;
         }
         _ => {
@@ -8070,11 +7530,7 @@ impl ::pb_jelly::Message for TestSmallStringPreserveUnrecognized {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestSmallStringPreserveUnrecognized", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestSmallStringPreserveUnrecognized", 1)?;
           self.compact = val;
         }
         _ => {
@@ -8629,125 +8085,75 @@ impl ::pb_jelly::Message for TestProto3Optional {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Optional", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "TestProto3Optional", 1)?;
           self.a_message = Some(val);
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 2)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 2)?;
           self.a_int32 = Some(val);
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 3)?;
-          let mut val: i64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 3)?;
           self.a_int64 = Some(val);
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 4)?;
-          let mut val: u32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 4)?;
           self.a_uint32 = Some(val);
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 5)?;
-          let mut val: u64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, u64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 5)?;
           self.a_uint64 = Some(val);
         }
         6 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestProto3Optional", 6)?;
-          let mut val: ::pb_jelly::Fixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestProto3Optional", 6)?;
           self.a_fixed64 = Some(val);
         }
         7 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestProto3Optional", 7)?;
-          let mut val: ::pb_jelly::Fixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Fixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestProto3Optional", 7)?;
           self.a_fixed32 = Some(val);
         }
         8 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestProto3Optional", 8)?;
-          let mut val: ::pb_jelly::Sfixed64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestProto3Optional", 8)?;
           self.a_sfixed64 = Some(val);
         }
         9 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestProto3Optional", 9)?;
-          let mut val: ::pb_jelly::Sfixed32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, ::pb_jelly::Sfixed32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestProto3Optional", 9)?;
           self.a_sfixed32 = Some(val);
         }
         10 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed64, "TestProto3Optional", 10)?;
-          let mut val: f64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f64>(buf, typ, ::pb_jelly::wire_format::Type::Fixed64, "TestProto3Optional", 10)?;
           self.a_double = Some(val);
         }
         11 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 11)?;
-          let mut val: bool = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, bool>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "TestProto3Optional", 11)?;
           self.a_bool = Some(val);
         }
         12 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Optional", 12)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestProto3Optional", 12)?;
           self.a_string = Some(val);
         }
         13 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Optional", 13)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::vec::Vec<u8> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::vec::Vec<u8>>(buf, typ, "TestProto3Optional", 13)?;
           self.a_bytes = Some(val);
         }
         14 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Fixed32, "TestProto3Optional", 14)?;
-          let mut val: f32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, f32>(buf, typ, ::pb_jelly::wire_format::Type::Fixed32, "TestProto3Optional", 14)?;
           self.a_float = Some(val);
         }
         15 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Optional", 15)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestProto3Optional", 15)?;
           self.real_oneof_1 = Some(TestProto3Optional_RealOneof1::RealOneof11(val));
         }
         16 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Optional", 16)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestProto3Optional", 16)?;
           self.real_oneof_1 = Some(TestProto3Optional_RealOneof1::RealOneof12(val));
         }
         17 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Optional", 17)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestProto3Optional", 17)?;
           oneof_real_oneof_2 = Some(TestProto3Optional_RealOneof2::RealOneof21(val));
         }
         18 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Optional", 18)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::std::string::String = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::std::string::String>(buf, typ, "TestProto3Optional", 18)?;
           oneof_real_oneof_2 = Some(TestProto3Optional_RealOneof2::RealOneof22(val));
         }
         _ => {
@@ -8987,19 +8393,11 @@ impl ::pb_jelly::Message for TestProto3Zerocopy {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Zerocopy", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::pb_jelly::Lazy<::bytes::Bytes> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::pb_jelly::Lazy<::bytes::Bytes>>(buf, typ, "TestProto3Zerocopy", 1)?;
           self.data1 = val;
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "TestProto3Zerocopy", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::pb_jelly::Lazy<::bytes::Bytes> = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::pb_jelly::Lazy<::bytes::Bytes>>(buf, typ, "TestProto3Zerocopy", 2)?;
           self.data2 = val;
         }
         _ => {
@@ -9228,43 +8626,23 @@ impl ::pb_jelly::Message for RecursiveOneof {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "RecursiveOneof", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: RecursiveOneof = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, RecursiveOneof>(buf, typ, "RecursiveOneof", 1)?;
           self.oneof_field = Some(RecursiveOneof_OneofField::Field(Box::new(val)));
         }
         2 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "RecursiveOneof", 2)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::proto_google::protobuf::empty::Empty = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::proto_google::protobuf::empty::Empty>(buf, typ, "RecursiveOneof", 2)?;
           self.oneof_field = Some(RecursiveOneof_OneofField::Empty);
         }
         3 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "RecursiveOneof", 3)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ::proto_google::protobuf::empty::Empty = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ::proto_google::protobuf::empty::Empty>(buf, typ, "RecursiveOneof", 3)?;
           self.oneof_field = Some(RecursiveOneof_OneofField::BoxedEmpty(Box::new(val)));
         }
         4 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "RecursiveOneof", 4)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "RecursiveOneof", 4)?;
           self.oneof_field = Some(RecursiveOneof_OneofField::NotBoxed(val));
         }
         5 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "RecursiveOneof", 5)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: ForeignMessage3 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, ForeignMessage3>(buf, typ, "RecursiveOneof", 5)?;
           self.oneof_field = Some(RecursiveOneof_OneofField::Boxed(Box::new(val)));
         }
         _ => {
@@ -9440,11 +8818,7 @@ impl ::pb_jelly::Message for MentionsKeywordPath {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "MentionsKeywordPath", 1)?;
-          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
-          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
-          let mut val: super::r#mod::r#struct::Message = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, super::r#mod::r#struct::Message>(buf, typ, "MentionsKeywordPath", 1)?;
           self.message = Some(val);
         }
         _ => {
@@ -9546,9 +8920,7 @@ impl ::pb_jelly::Message for NonNullableOneofKeyword {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "NonNullableOneofKeyword", 1)?;
-          let mut val: i64 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i64>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "NonNullableOneofKeyword", 1)?;
           oneof_async = Some(NonNullableOneofKeyword_Async::A(val));
         }
         _ => {
@@ -9653,9 +9025,7 @@ impl ::pb_jelly::Message for NonNullableEnumKeyword {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "NonNullableEnumKeyword", 1)?;
-          let mut val: TestMessage3_NestedMessage_NonNullableEnum = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, TestMessage3_NestedMessage_NonNullableEnum>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "NonNullableEnumKeyword", 1)?;
           r#enum = Some(val);
         }
         _ => {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
@@ -38,14 +38,6 @@ impl ::pb_jelly::Message for InpMessage {
     size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.i, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.i != <i32 as ::std::default::Default>::default() {
-      let val = &self.i;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
-    size
-  }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
     ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.i, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
@@ -122,14 +114,6 @@ impl ::pb_jelly::Message for OutMessage {
   fn compute_size(&self) -> usize {
     let mut size = 0;
     size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.o, 1, ::pb_jelly::wire_format::Type::Varint);
-    size
-  }
-  fn compute_grpc_slices_size(&self) -> usize {
-    let mut size = 0;
-    if self.o != <i32 as ::std::default::Default>::default() {
-      let val = &self.o;
-      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
-    }
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
@@ -54,11 +54,7 @@ impl ::pb_jelly::Message for InpMessage {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.i != <i32 as ::std::default::Default>::default() {
-      let val = &self.i;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.i, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
@@ -151,11 +147,7 @@ impl ::pb_jelly::Message for OutMessage {
     size
   }
   fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
-    if self.o != <i32 as ::std::default::Default>::default() {
-      let val = &self.o;
-      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::Varint, w)?;
-      ::pb_jelly::Message::serialize(val, w)?;
-    }
+    ::pb_jelly::helpers::serialize_scalar::<W, i32>(w, &self.o, 1, ::pb_jelly::wire_format::Type::Varint)?;
     Ok(())
   }
   fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
@@ -35,14 +35,7 @@ impl ::pb_jelly::Message for InpMessage {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut i_size = 0;
-    if self.i != <i32 as ::std::default::Default>::default() {
-      let val = &self.i;
-      let l = ::pb_jelly::Message::compute_size(val);
-      i_size += ::pb_jelly::wire_format::serialized_length(1);
-      i_size += l;
-    }
-    size += i_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.i, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {
@@ -128,14 +121,7 @@ impl ::pb_jelly::Message for OutMessage {
   }
   fn compute_size(&self) -> usize {
     let mut size = 0;
-    let mut o_size = 0;
-    if self.o != <i32 as ::std::default::Default>::default() {
-      let val = &self.o;
-      let l = ::pb_jelly::Message::compute_size(val);
-      o_size += ::pb_jelly::wire_format::serialized_length(1);
-      o_size += l;
-    }
-    size += o_size;
+    size += ::pb_jelly::helpers::compute_size_scalar::<i32>(&self.o, 1, ::pb_jelly::wire_format::Type::Varint);
     size
   }
   fn compute_grpc_slices_size(&self) -> usize {

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/servicepb.rs.expected
@@ -65,9 +65,7 @@ impl ::pb_jelly::Message for InpMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "InpMessage", 1)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "InpMessage", 1)?;
           self.i = val;
         }
         _ => {
@@ -164,9 +162,7 @@ impl ::pb_jelly::Message for OutMessage {
     while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
       match field_number {
         1 => {
-          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "OutMessage", 1)?;
-          let mut val: i32 = ::std::default::Default::default();
-          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "OutMessage", 1)?;
           self.o = val;
         }
         _ => {

--- a/pb-test/pb_test_gen/src/main.rs
+++ b/pb-test/pb_test_gen/src/main.rs
@@ -1,5 +1,8 @@
 use pb_jelly_gen::GenProtos;
-use std::{env, fs};
+use std::{
+    env,
+    fs,
+};
 
 #[cfg(feature = "bench_prost")]
 use prost_build;

--- a/pb-test/proto/packages/pbtest/pbtest3.proto
+++ b/pb-test/proto/packages/pbtest/pbtest3.proto
@@ -358,6 +358,10 @@ message TestProto3Zerocopy {
     bytes data2 = 2 [(rust.zero_copy) = true];
 }
 
+message TestProto3ContainsZerocopy {
+    TestProto3Zerocopy inner = 1;
+}
+
 message RecursiveOneof {
     oneof oneof_field {
         // This field should be boxed automatically.

--- a/pb-test/src/pbtest.rs
+++ b/pb-test/src/pbtest.rs
@@ -879,13 +879,19 @@ fn test_proto3_zerocopy_read() {
 
     let mut proto = TestProto3Zerocopy::default();
     proto.deserialize(&mut Cursor::new(data.clone())).unwrap();
-    let data1 = proto.data1.into_buffer();
-    let data2 = proto.data2.into_buffer();
+    let data1 = proto.data1.clone().into_buffer();
+    let data2 = proto.data2.clone().into_buffer();
     assert_eq!(data1, &b"zerocopy"[..]);
     assert_eq!(data2, &b"zerocopy2"[..]);
     // The deserialized buffers should point into `data`.
     data.slice_ref(data1.as_ref());
     data.slice_ref(data2.as_ref());
+
+    assert_eq!(proto.compute_grpc_slices_size(), "zerocopy".len() + "zerocopy2".len());
+    assert_eq!(
+        TestProto3ContainsZerocopy { inner: Some(proto) }.compute_grpc_slices_size(),
+        "zerocopy".len() + "zerocopy2".len()
+    );
 }
 
 // Test that boxing works properly for oneof fields.


### PR DESCRIPTION
Depends on #157.

This PR implements a series of optimizations to try to reduce the amount of generated code with the aim of speeding up compilation. Altogether this makes our slowest proto crate a bit over 10% faster to compile (~41s to ~35s).

The changes, in separate commits, are:
- Codify the three separate cases for deserialization (packed repeated, length-delimited, non-length-delimited) into helper functions
- Move `into_known` for open enums into the `OpenProtoEnum` trait, then use it to default-impl the other methods of that trait
- Add special-cased helper functions for the common case of serializing (and compute_size-ing) non-optional proto3 scalar fields
- Iterate optional fields using `if let` instead of `for`
- Skip `compute_grpc_slices_size` calls/impls for fields/types where we know statically that no Lazy<> fields are present. This uses the SCC analysis.