### PR TITLE
Replace ctype=CORD with rust.blob extension field

### DIFF
--- a/pb-jelly-gen/codegen/codegen.py
+++ b/pb-jelly-gen/codegen/codegen.py
@@ -30,7 +30,6 @@ from google.protobuf.descriptor_pb2 import (
     EnumDescriptorProto,
     EnumValueDescriptorProto,
     FieldDescriptorProto,
-    FieldOptions,
     FileDescriptorProto,
     OneofDescriptorProto,
     SourceCodeInfo,
@@ -324,7 +323,7 @@ class RustType(object):
     def is_blob(self) -> bool:
         return (
             self.field.type == FieldDescriptorProto.TYPE_BYTES
-            and self.field.options.ctype == FieldOptions.CORD
+            and self.field.options.Extensions[extensions_pb2.blob]
         )
 
     def is_lazy_bytes(self) -> bool:
@@ -1786,7 +1785,7 @@ class Context(object):
 
                 # If we use a Blob type, or GRPC Slice
                 if typ == FieldDescriptorProto.TYPE_BYTES and (
-                    field.options.ctype == FieldOptions.CORD
+                    field.options.Extensions[extensions_pb2.blob]
                     or field.options.Extensions[extensions_pb2.grpc_slices]
                 ):
                     (impls_eq, impls_copy) = (False, False)  # Blob is not eq/copy

--- a/pb-jelly-gen/codegen/proto/rust/extensions_pb2.py
+++ b/pb-jelly-gen/codegen/proto/rust/extensions_pb2.py
@@ -14,13 +14,14 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import descriptor_pb2 as google_dot_protobuf_dot_descriptor__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15rust/extensions.proto\x12\x04rust\x1a google/protobuf/descriptor.proto:/\n\x06\x62ox_it\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\x08:4\n\x0bgrpc_slices\x12\x1d.google.protobuf.FieldOptions\x18\xd3\x86\x03 \x01(\x08:-\n\x04type\x12\x1d.google.protobuf.FieldOptions\x18\xd4\x86\x03 \x01(\t:2\n\tzero_copy\x12\x1d.google.protobuf.FieldOptions\x18\xd7\x86\x03 \x01(\x08:,\n\x03sso\x12\x1d.google.protobuf.FieldOptions\x18\xd9\x86\x03 \x01(\x08:7\n\x0enullable_field\x12\x1d.google.protobuf.FieldOptions\x18\xd8\x86\x03 \x01(\x08:A\n\x19\x65rr_if_default_or_unknown\x12\x1c.google.protobuf.EnumOptions\x18\xd2\x86\x03 \x01(\x08:3\n\x0b\x63losed_enum\x12\x1c.google.protobuf.EnumOptions\x18\xd8\x86\x03 \x01(\x08:@\n\x15preserve_unrecognized\x12\x1f.google.protobuf.MessageOptions\x18\xd6\x86\x03 \x01(\x08:7\n\x08nullable\x12\x1d.google.protobuf.OneofOptions\x18\xd1\x86\x03 \x01(\x08:\x04true:;\n\x0cserde_derive\x12\x1c.google.protobuf.FileOptions\x18\xd5\x86\x03 \x01(\x08:\x05\x66\x61lse')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15rust/extensions.proto\x12\x04rust\x1a google/protobuf/descriptor.proto:/\n\x06\x62ox_it\x12\x1d.google.protobuf.FieldOptions\x18\xd0\x86\x03 \x01(\x08:4\n\x0bgrpc_slices\x12\x1d.google.protobuf.FieldOptions\x18\xd3\x86\x03 \x01(\x08:-\n\x04\x62lob\x12\x1d.google.protobuf.FieldOptions\x18\xda\x86\x03 \x01(\x08:-\n\x04type\x12\x1d.google.protobuf.FieldOptions\x18\xd4\x86\x03 \x01(\t:2\n\tzero_copy\x12\x1d.google.protobuf.FieldOptions\x18\xd7\x86\x03 \x01(\x08:,\n\x03sso\x12\x1d.google.protobuf.FieldOptions\x18\xd9\x86\x03 \x01(\x08:7\n\x0enullable_field\x12\x1d.google.protobuf.FieldOptions\x18\xd8\x86\x03 \x01(\x08:A\n\x19\x65rr_if_default_or_unknown\x12\x1c.google.protobuf.EnumOptions\x18\xd2\x86\x03 \x01(\x08:3\n\x0b\x63losed_enum\x12\x1c.google.protobuf.EnumOptions\x18\xd8\x86\x03 \x01(\x08:@\n\x15preserve_unrecognized\x12\x1f.google.protobuf.MessageOptions\x18\xd6\x86\x03 \x01(\x08:7\n\x08nullable\x12\x1d.google.protobuf.OneofOptions\x18\xd1\x86\x03 \x01(\x08:\x04true:;\n\x0cserde_derive\x12\x1c.google.protobuf.FileOptions\x18\xd5\x86\x03 \x01(\x08:\x05\x66\x61lse')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'rust.extensions_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
   google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(box_it)
   google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(grpc_slices)
+  google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(blob)
   google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(type)
   google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(zero_copy)
   google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(sso)

--- a/pb-jelly-gen/codegen/rust/extensions.proto
+++ b/pb-jelly-gen/codegen/rust/extensions.proto
@@ -13,7 +13,10 @@ import "google/protobuf/descriptor.proto";
 extend google.protobuf.FieldOptions {
     // Generate this field in a Box as opposed to inline Option
     optional bool box_it = 50000;
+    // Generates a `Lazy<VecSlice>`
     optional bool grpc_slices = 50003;
+    // Generates a `Lazy<WrappedBlob>`
+    optional bool blob = 50010;
     // Use a different Rust type which implements `pb::Message` to represent the field.
     // All paths must be fully qualified, as in `::my_crate::full::path::to::type`.
     // This only works with proto3.

--- a/pb-jelly/src/buffer.rs
+++ b/pb-jelly/src/buffer.rs
@@ -17,7 +17,7 @@
 //! of copying large buffers during serialization and deserialization.
 //!
 //! To support this, messages may contain zerocopy fields using the [`Lazy`] type.
-//! `pb-jelly-gen` may generate these using the `CORD`, `grpc_slices`, or `zero_copy` options; they
+//! `pb-jelly-gen` may generate these using the `blob`, `grpc_slices`, or `zero_copy` options; they
 //! use different underlying types, which must implement [PbBuffer], but they all behave similarly.
 //!
 //! [PbBufferReader] and a [PbBufferWriter] have the opportunity to recognize [Lazy] fields.

--- a/pb-test/proto/includes/rust/extensions.proto
+++ b/pb-test/proto/includes/rust/extensions.proto
@@ -13,7 +13,10 @@ import "google/protobuf/descriptor.proto";
 extend google.protobuf.FieldOptions {
     // Generate this field in a Box as opposed to inline Option
     optional bool box_it = 50000;
+    // Generates a `Lazy<VecSlice>`
     optional bool grpc_slices = 50003;
+    // Generates a `Lazy<WrappedBlob>`
+    optional bool blob = 50010;
     // Use a different Rust type which implements `pb::Message` to represent the field.
     // All paths must be fully qualified, as in `::my_crate::full::path::to::type`.
     // This only works with proto3.


### PR DESCRIPTION
CORD has gained a meaning upstream but isn't complete, we shouldn't be using it.