### PR TITLE
Implement read support for proto2 extensions

### DIFF
--- a/pb-jelly/src/extensions.rs
+++ b/pb-jelly/src/extensions.rs
@@ -1,0 +1,133 @@
+use std::io;
+use std::marker::PhantomData;
+
+use crate::{
+    ensure_wire_format,
+    varint,
+    wire_format,
+    Message,
+    PbBufferReader,
+    Unrecognized,
+};
+
+/// Indicates that a message type has extension ranges defined.
+/// See <https://protobuf.dev/programming-guides/proto2/#extensions> for details.
+pub trait Extensible: Message {
+    /// Attempts to read the given extension field from `self`.
+    ///
+    /// Returns `Err(_)` if the field was found but could not be deserialized as the declared field type.
+    fn get_extension<E: Extension<Extendee = Self>>(&self, extension: E) -> io::Result<E::Value> {
+        extension.get(self)
+    }
+
+    /// Returns a reference to the `_extensions` field.
+    /// This is intended to be implemented by generated code and isn't very useful for users of pb-jelly,
+    /// so it's doc(hidden).
+    #[doc(hidden)]
+    fn _extensions(&self) -> &Unrecognized;
+}
+
+/// Abstracts over [SingularExtension]/[RepeatedExtension].
+pub trait Extension {
+    type Extendee: Extensible;
+    type Value;
+    fn get(&self, m: &Self::Extendee) -> io::Result<Self::Value>;
+}
+
+/// An extension field. See <https://protobuf.dev/programming-guides/proto2/#extensions> for details.
+pub struct SingularExtension<T, U> {
+    pub field_number: u32,
+    pub wire_format: wire_format::Type,
+    pub name: &'static str,
+    _phantom: PhantomData<fn(&T) -> U>,
+}
+
+impl<T, U> SingularExtension<T, U> {
+    pub const fn new(field_number: u32, wire_format: wire_format::Type, name: &'static str) -> Self {
+        Self {
+            field_number,
+            wire_format,
+            name,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, U> Copy for SingularExtension<T, U> {}
+impl<T, U> Clone for SingularExtension<T, U> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Extensible, U: Message> Extension for SingularExtension<T, U> {
+    type Extendee = T;
+    type Value = Option<U>;
+
+    fn get(&self, m: &Self::Extendee) -> io::Result<Option<U>> {
+        Ok(match dbg!(m._extensions().get_singular_field(self.field_number)) {
+            Some((field, wire_format)) => {
+                let mut buf = io::Cursor::new(field);
+                ensure_wire_format(wire_format, self.wire_format, self.name, self.field_number)?;
+                if wire_format == wire_format::Type::LengthDelimited {
+                    // we don't actually need this since we already have the length of `field`
+                    varint::read(&mut buf)?;
+                }
+                let mut msg = U::default();
+                msg.deserialize(&mut buf)?;
+                Some(msg)
+            },
+            None => None,
+        })
+    }
+}
+
+/// A `repeated` extension field. See <https://protobuf.dev/programming-guides/proto2/#extensions> for details.
+pub struct RepeatedExtension<T, U> {
+    pub field_number: u32,
+    pub wire_format: wire_format::Type,
+    pub name: &'static str,
+    _phantom: PhantomData<fn(&T) -> U>,
+}
+
+impl<T, U> RepeatedExtension<T, U> {
+    pub const fn new(field_number: u32, wire_format: wire_format::Type, name: &'static str) -> Self {
+        Self {
+            field_number,
+            wire_format,
+            name,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, U> Copy for RepeatedExtension<T, U> {}
+impl<T, U> Clone for RepeatedExtension<T, U> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Extensible, U: Message> Extension for RepeatedExtension<T, U> {
+    type Extendee = T;
+    type Value = Vec<U>;
+
+    fn get(&self, m: &Self::Extendee) -> io::Result<Vec<U>> {
+        let mut result = vec![];
+        let mut buf = io::Cursor::new(m._extensions().get_fields(self.field_number));
+        while let Some((_field_number, wire_format)) = wire_format::read(&mut buf)? {
+            ensure_wire_format(wire_format, self.wire_format, self.name, self.field_number)?;
+            let mut msg = U::default();
+            if wire_format == wire_format::Type::LengthDelimited {
+                let length = varint::read(&mut buf)?.expect("corrupted Unrecognized");
+                msg.deserialize(&mut buf.split(length as usize))?;
+            } else {
+                // we rely on the fact that the appropriate `Message` impls for i32/Fixed32/etc. only read the prefix of
+                // `buf`. this is a little dirty
+                msg.deserialize(&mut buf)?;
+            }
+            result.push(msg);
+        }
+        Ok(result)
+    }
+}

--- a/pb-jelly/src/helpers.rs
+++ b/pb-jelly/src/helpers.rs
@@ -15,7 +15,7 @@ pub fn deserialize_packed<B: PbBufferReader, T: Message>(
     typ: wire_format::Type,
     expected_wire_format: wire_format::Type,
     msg_name: &'static str,
-    field_number: usize,
+    field_number: u32,
     out: &mut Vec<T>,
 ) -> io::Result<()> {
     match typ {
@@ -42,7 +42,7 @@ pub fn deserialize_length_delimited<B: PbBufferReader, T: Message>(
     buf: &mut B,
     typ: wire_format::Type,
     msg_name: &'static str,
-    field_number: usize,
+    field_number: u32,
 ) -> io::Result<T> {
     ensure_wire_format(typ, wire_format::Type::LengthDelimited, msg_name, field_number)?;
     let len = varint::ensure_read(buf)?;
@@ -57,7 +57,7 @@ pub fn deserialize_known_length<B: PbBufferReader, T: Message>(
     typ: wire_format::Type,
     expected_wire_format: wire_format::Type,
     msg_name: &'static str,
-    field_number: usize,
+    field_number: u32,
 ) -> io::Result<T> {
     ensure_wire_format(typ, expected_wire_format, msg_name, field_number)?;
     let mut val: T = Default::default();

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/extensions.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/extensions.rs.expected
@@ -1,0 +1,403 @@
+// @generated, do not edit
+#[derive(Clone, Debug, PartialEq)]
+pub struct Msg {
+  pub base_field: ::std::option::Option<i32>,
+  pub _extensions: ::pb_jelly::Unrecognized,
+}
+impl Msg {
+  pub fn has_base_field(&self) -> bool {
+    self.base_field.is_some()
+  }
+  pub fn set_base_field(&mut self, v: i32) {
+    self.base_field = Some(v);
+  }
+  pub fn get_base_field(&self) -> i32 {
+    self.base_field.unwrap_or(0)
+  }
+}
+impl ::std::default::Default for Msg {
+  fn default() -> Self {
+    Msg {
+      base_field: ::std::default::Default::default(),
+      _extensions: ::pb_jelly::Unrecognized::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref Msg_default: Msg = Msg::default();
+}
+impl ::pb_jelly::Message for Msg {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "Msg",
+      full_name: "pbtest.Msg",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "base_field",
+          full_name: "pbtest.Msg.base_field",
+          index: 0,
+          number: 250,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut base_field_size = 0;
+    if let Some(ref val) = self.base_field {
+      let l = ::pb_jelly::Message::compute_size(val);
+      base_field_size += ::pb_jelly::wire_format::serialized_length(250);
+      base_field_size += l;
+    }
+    size += base_field_size;
+    size += self._extensions.compute_size();
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if let Some(ref val) = self.base_field {
+      ::pb_jelly::wire_format::write(250, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    self._extensions.serialize(w)?;
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        250 => {
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Msg", 250)?;
+          self.base_field = Some(val);
+        }
+        100..=200 | 300..=536870911 => {
+          self._extensions.gather(field_number, typ, &mut buf)?;
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for Msg {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "base_field" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.base_field.get_or_insert_with(::std::default::Default::default))
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+impl ::pb_jelly::extensions::Extensible for Msg {
+  fn _extensions(&self) -> &::pb_jelly::Unrecognized {
+    &self._extensions
+  }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct FakeMsg {
+  pub base_field: ::std::option::Option<i32>,
+  pub singular_primitive: ::std::option::Option<i32>,
+  pub singular_message: ::std::option::Option<super::pbtest3::ForeignMessage3>,
+  pub repeated_primitive: ::std::vec::Vec<i32>,
+  pub repeated_message: ::std::vec::Vec<super::pbtest3::ForeignMessage3>,
+}
+impl FakeMsg {
+  pub fn has_base_field(&self) -> bool {
+    self.base_field.is_some()
+  }
+  pub fn set_base_field(&mut self, v: i32) {
+    self.base_field = Some(v);
+  }
+  pub fn get_base_field(&self) -> i32 {
+    self.base_field.unwrap_or(0)
+  }
+  pub fn has_singular_primitive(&self) -> bool {
+    self.singular_primitive.is_some()
+  }
+  pub fn set_singular_primitive(&mut self, v: i32) {
+    self.singular_primitive = Some(v);
+  }
+  pub fn get_singular_primitive(&self) -> i32 {
+    self.singular_primitive.unwrap_or(0)
+  }
+  pub fn has_singular_message(&self) -> bool {
+    self.singular_message.is_some()
+  }
+  pub fn set_singular_message(&mut self, v: super::pbtest3::ForeignMessage3) {
+    self.singular_message = Some(v);
+  }
+  pub fn take_singular_message(&mut self) -> super::pbtest3::ForeignMessage3 {
+    self.singular_message.take().unwrap_or_default()
+  }
+  pub fn get_singular_message(&self) -> &super::pbtest3::ForeignMessage3 {
+    self.singular_message.as_ref().unwrap_or(&super::pbtest3::ForeignMessage3_default)
+  }
+  pub fn set_repeated_primitive(&mut self, v: ::std::vec::Vec<i32>) {
+    self.repeated_primitive = v;
+  }
+  pub fn take_repeated_primitive(&mut self) -> ::std::vec::Vec<i32> {
+    ::std::mem::take(&mut self.repeated_primitive)
+  }
+  pub fn get_repeated_primitive(&self) -> &[i32] {
+    &self.repeated_primitive
+  }
+  pub fn mut_repeated_primitive(&mut self) -> &mut ::std::vec::Vec<i32> {
+    &mut self.repeated_primitive
+  }
+  pub fn set_repeated_message(&mut self, v: ::std::vec::Vec<super::pbtest3::ForeignMessage3>) {
+    self.repeated_message = v;
+  }
+  pub fn take_repeated_message(&mut self) -> ::std::vec::Vec<super::pbtest3::ForeignMessage3> {
+    ::std::mem::take(&mut self.repeated_message)
+  }
+  pub fn get_repeated_message(&self) -> &[super::pbtest3::ForeignMessage3] {
+    &self.repeated_message
+  }
+  pub fn mut_repeated_message(&mut self) -> &mut ::std::vec::Vec<super::pbtest3::ForeignMessage3> {
+    &mut self.repeated_message
+  }
+}
+impl ::std::default::Default for FakeMsg {
+  fn default() -> Self {
+    FakeMsg {
+      base_field: ::std::default::Default::default(),
+      singular_primitive: ::std::default::Default::default(),
+      singular_message: ::std::default::Default::default(),
+      repeated_primitive: ::std::default::Default::default(),
+      repeated_message: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref FakeMsg_default: FakeMsg = FakeMsg::default();
+}
+impl ::pb_jelly::Message for FakeMsg {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "FakeMsg",
+      full_name: "pbtest.FakeMsg",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "base_field",
+          full_name: "pbtest.FakeMsg.base_field",
+          index: 0,
+          number: 250,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+        ::pb_jelly::FieldDescriptor {
+          name: "singular_primitive",
+          full_name: "pbtest.FakeMsg.singular_primitive",
+          index: 1,
+          number: 101,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+        ::pb_jelly::FieldDescriptor {
+          name: "singular_message",
+          full_name: "pbtest.FakeMsg.singular_message",
+          index: 2,
+          number: 301,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+        ::pb_jelly::FieldDescriptor {
+          name: "repeated_primitive",
+          full_name: "pbtest.FakeMsg.repeated_primitive",
+          index: 3,
+          number: 300,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Repeated,
+          oneof_index: None,
+        },
+        ::pb_jelly::FieldDescriptor {
+          name: "repeated_message",
+          full_name: "pbtest.FakeMsg.repeated_message",
+          index: 4,
+          number: 200,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Repeated,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut base_field_size = 0;
+    if let Some(ref val) = self.base_field {
+      let l = ::pb_jelly::Message::compute_size(val);
+      base_field_size += ::pb_jelly::wire_format::serialized_length(250);
+      base_field_size += l;
+    }
+    size += base_field_size;
+    let mut singular_primitive_size = 0;
+    if let Some(ref val) = self.singular_primitive {
+      let l = ::pb_jelly::Message::compute_size(val);
+      singular_primitive_size += ::pb_jelly::wire_format::serialized_length(101);
+      singular_primitive_size += l;
+    }
+    size += singular_primitive_size;
+    let mut singular_message_size = 0;
+    if let Some(ref val) = self.singular_message {
+      let l = ::pb_jelly::Message::compute_size(val);
+      singular_message_size += ::pb_jelly::wire_format::serialized_length(301);
+      singular_message_size += ::pb_jelly::varint::serialized_length(l as u64);
+      singular_message_size += l;
+    }
+    size += singular_message_size;
+    let mut repeated_primitive_size = 0;
+    for val in &self.repeated_primitive {
+      let l = ::pb_jelly::Message::compute_size(val);
+      repeated_primitive_size += ::pb_jelly::wire_format::serialized_length(300);
+      repeated_primitive_size += l;
+    }
+    size += repeated_primitive_size;
+    let mut repeated_message_size = 0;
+    for val in &self.repeated_message {
+      let l = ::pb_jelly::Message::compute_size(val);
+      repeated_message_size += ::pb_jelly::wire_format::serialized_length(200);
+      repeated_message_size += ::pb_jelly::varint::serialized_length(l as u64);
+      repeated_message_size += l;
+    }
+    size += repeated_message_size;
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if let Some(ref val) = self.singular_primitive {
+      ::pb_jelly::wire_format::write(101, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    for val in &self.repeated_message {
+      ::pb_jelly::wire_format::write(200, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    if let Some(ref val) = self.base_field {
+      ::pb_jelly::wire_format::write(250, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    for val in &self.repeated_primitive {
+      ::pb_jelly::wire_format::write(300, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    if let Some(ref val) = self.singular_message {
+      ::pb_jelly::wire_format::write(301, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        250 => {
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "FakeMsg", 250)?;
+          self.base_field = Some(val);
+        }
+        101 => {
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "FakeMsg", 101)?;
+          self.singular_primitive = Some(val);
+        }
+        301 => {
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, super::pbtest3::ForeignMessage3>(buf, typ, "FakeMsg", 301)?;
+          self.singular_message = Some(val);
+        }
+        300 => {
+          ::pb_jelly::helpers::deserialize_packed::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "FakeMsg", 300, &mut self.repeated_primitive)?;
+        }
+        200 => {
+          let val = ::pb_jelly::helpers::deserialize_length_delimited::<B, super::pbtest3::ForeignMessage3>(buf, typ, "FakeMsg", 200)?;
+          self.repeated_message.push(val);
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for FakeMsg {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "base_field" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.base_field.get_or_insert_with(::std::default::Default::default))
+      }
+      "singular_primitive" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.singular_primitive.get_or_insert_with(::std::default::Default::default))
+      }
+      "singular_message" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.singular_message.get_or_insert_with(::std::default::Default::default))
+      }
+      "repeated_primitive" => {
+        unimplemented!("Repeated fields are not currently supported.")
+      }
+      "repeated_message" => {
+        unimplemented!("Repeated fields are not currently supported.")
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+
+pub const SINGULAR_PRIMITIVE: ::pb_jelly::extensions::SingularExtension<Msg, i32> =
+    ::pb_jelly::extensions::SingularExtension::new(
+        101,
+        ::pb_jelly::wire_format::Type::Varint,
+        "singular_primitive",
+    );
+
+pub const SINGULAR_MESSAGE: ::pb_jelly::extensions::SingularExtension<Msg, super::pbtest3::ForeignMessage3> =
+    ::pb_jelly::extensions::SingularExtension::new(
+        301,
+        ::pb_jelly::wire_format::Type::LengthDelimited,
+        "singular_message",
+    );
+
+pub const REPEATED_PRIMITIVE: ::pb_jelly::extensions::RepeatedExtension<Msg, i32> =
+    ::pb_jelly::extensions::RepeatedExtension::new(
+        300,
+        ::pb_jelly::wire_format::Type::Varint,
+        "repeated_primitive",
+    );
+
+pub const REPEATED_MESSAGE: ::pb_jelly::extensions::RepeatedExtension<Msg, super::pbtest3::ForeignMessage3> =
+    ::pb_jelly::extensions::RepeatedExtension::new(
+        200,
+        ::pb_jelly::wire_format::Type::LengthDelimited,
+        "repeated_message",
+    );
+

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
@@ -25,6 +25,7 @@
 extern crate lazy_static;
 
 pub mod bench;
+pub mod extensions;
 pub mod r#mod;
 pub mod pbtest2;
 pub mod pbtest3;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/pbtest3.rs.expected
@@ -5491,7 +5491,8 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized1 {
         }
       }
     }
-    unrecognized.serialize(&mut self._unrecognized)?;
+    self._unrecognized.reserve(unrecognized.compute_size());
+    unrecognized.serialize(&mut std::io::Cursor::new(&mut self._unrecognized))?;
     Ok(())
   }
 }
@@ -5796,7 +5797,8 @@ impl ::pb_jelly::Message for TestPreserveUnrecognized2 {
         }
       }
     }
-    unrecognized.serialize(&mut self._unrecognized)?;
+    self._unrecognized.reserve(unrecognized.compute_size());
+    unrecognized.serialize(&mut std::io::Cursor::new(&mut self._unrecognized))?;
     Ok(())
   }
 }
@@ -5902,7 +5904,8 @@ impl ::pb_jelly::Message for TestPreserveUnrecognizedEmpty {
         }
       }
     }
-    unrecognized.serialize(&mut self._unrecognized)?;
+    self._unrecognized.reserve(unrecognized.compute_size());
+    unrecognized.serialize(&mut std::io::Cursor::new(&mut self._unrecognized))?;
     Ok(())
   }
 }
@@ -6217,7 +6220,8 @@ impl ::pb_jelly::Message for TestSmallStringPreserveUnrecognized {
         }
       }
     }
-    unrecognized.serialize(&mut self._unrecognized)?;
+    self._unrecognized.reserve(unrecognized.compute_size());
+    unrecognized.serialize(&mut std::io::Cursor::new(&mut self._unrecognized))?;
     Ok(())
   }
 }

--- a/pb-test/proto/packages/pbtest/extensions.proto
+++ b/pb-test/proto/packages/pbtest/extensions.proto
@@ -1,0 +1,26 @@
+syntax = "proto2";
+package pbtest;
+
+import "pbtest/pbtest3.proto";
+
+message Msg {
+    optional int32 base_field = 250;
+    extensions 100 to 200;
+    extensions 300 to max;
+}
+
+extend Msg {
+    optional int32 singular_primitive = 101;
+    optional ForeignMessage3 singular_message = 301;
+    repeated int32 repeated_primitive = 300;
+    repeated ForeignMessage3 repeated_message = 200;
+}
+
+message FakeMsg {
+    optional int32 base_field = 250;
+
+    optional int32 singular_primitive = 101;
+    optional ForeignMessage3 singular_message = 301;
+    repeated int32 repeated_primitive = 300;
+    repeated ForeignMessage3 repeated_message = 200;
+}

--- a/pb-test/src/verify_generated_files.rs
+++ b/pb-test/src/verify_generated_files.rs
@@ -23,7 +23,7 @@ fn verify_generated_files() {
 
     // Assert the correct number of pb-test generated files
     // Developers - please change this number if the change is intentional
-    assert_eq!(proto_files.len(), 15);
+    assert_eq!(proto_files.len(), 16);
 
     // Assert contents of the generated files
     for proto_file in proto_files {


### PR DESCRIPTION
Adds new codegen for messages with extension ranges defined,
and generates extension fields as constants.

The syntax is `m.get_extension(extensions::MY_EXTENSION)`,
which can return `Err` if parsing fails. This is not super ergonomic.

Extensions are read-only for now.