### PR TITLE
Remove serde impls for Fixed/Signed types

### DIFF
--- a/pb-jelly-gen/src/codegen.rs
+++ b/pb-jelly-gen/src/codegen.rs
@@ -942,7 +942,7 @@ impl<'a, 'ctx> CodeWriter<'a, 'ctx> {
         let ctx = self;
         ctx.write_comments(ctx.source_code_info_by_scl.get(scl).copied());
         if ctx.derive_serde {
-            ctx.write("#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Deserialize, Serialize)]");
+            ctx.write("#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, ::serde_derive::Deserialize, ::serde_derive::Serialize)]");
         } else {
             ctx.write("#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]");
         }
@@ -1035,7 +1035,7 @@ impl<'a, 'ctx> CodeWriter<'a, 'ctx> {
         // Generate an open enum
         ctx.write_comments(ctx.source_code_info_by_scl.get(scl).copied());
         if ctx.derive_serde {
-            ctx.write("#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]");
+            ctx.write("#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, ::serde_derive::Deserialize, ::serde_derive::Serialize)]");
         } else {
             ctx.write("#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]");
         }
@@ -1210,7 +1210,7 @@ impl<'a, 'ctx> CodeWriter<'a, 'ctx> {
 
         let mut derives = vec!["Clone", "Debug", "PartialEq"];
         if ctx.derive_serde {
-            derives.extend(["Deserialize", "Serialize"]);
+            derives.extend(["::serde_derive::Deserialize", "::serde_derive::Serialize"]);
         }
 
         let impls = &ctx.ctx.impls_by_msg[&ProtoType::new(
@@ -2544,16 +2544,12 @@ impl<'a> Context<'a> {
 
             all_deps.remove("std");
 
-            let mut features: IndexMap<&str, &str> = [
-                ("serde", r#"features=["serde_derive"]"#),
-                ("compact_str", r#"features=["bytes"]"#),
-            ]
-            .iter()
-            .copied()
-            .collect();
+            let mut features: IndexMap<&str, &str> =
+                [("compact_str", r#"features=["bytes"]"#)].iter().copied().collect();
 
             if derive_serde {
                 all_deps.insert("serde");
+                all_deps.insert("serde_derive");
                 features.insert("compact_str", r#"features=["bytes", "serde"]"#);
             }
 
@@ -2588,11 +2584,11 @@ impl<'a> Context<'a> {
             all_deps.remove("std");
 
             let mut features: BTreeMap<&str, String> = BTreeMap::new();
-            features.insert("serde", "features=[\"serde_derive\"]".to_string());
             features.insert("compact_str", "features=[\"bytes\"]".to_string());
 
             if derive_serde {
                 all_deps.insert("serde");
+                all_deps.insert("serde_derive");
                 features.insert("compact_str", "features=[\"bytes\", \"serde\"]".to_string());
             }
 
@@ -2600,6 +2596,7 @@ impl<'a> Context<'a> {
             versions.insert("lazy_static", "version = \"1.4.0\"".to_string());
             versions.insert("pb-jelly", "version = \"0.0.16\"".to_string());
             versions.insert("serde", "version = \"1.0\"".to_string());
+            versions.insert("serde_derive", "version = \"1.0\"".to_string());
             versions.insert("bytes", "version = \"1.0\"".to_string());
             versions.insert("compact_str", "version = \"0.5\"".to_string());
 

--- a/pb-jelly/Cargo.toml
+++ b/pb-jelly/Cargo.toml
@@ -17,4 +17,3 @@ categories = ["encoding", "parsing", "web-programming"]
 byteorder = "1.4"
 bytes = "1.0"
 compact_str = { version = "0.5", features = ["bytes"] }
-serde = { version = "1.0", features = ["derive"] }

--- a/pb-jelly/src/base_types.rs
+++ b/pb-jelly/src/base_types.rs
@@ -212,7 +212,7 @@ impl Message for i64 {
 
 impl Reflection for i64 {}
 
-#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Signed64(pub i64);
 
 impl Signed64 {
@@ -259,7 +259,7 @@ impl DerefMut for Signed64 {
     }
 }
 
-#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Signed32(pub i32);
 
 impl Signed32 {
@@ -306,7 +306,7 @@ impl DerefMut for Signed32 {
     }
 }
 
-#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Fixed64(pub u64);
 
 impl Message for Fixed64 {
@@ -342,7 +342,7 @@ impl DerefMut for Fixed64 {
     }
 }
 
-#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Fixed32(pub u32);
 
 impl Message for Fixed32 {
@@ -378,7 +378,7 @@ impl DerefMut for Fixed32 {
     }
 }
 
-#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Sfixed64(pub i64);
 
 impl Message for Sfixed64 {
@@ -414,7 +414,7 @@ impl DerefMut for Sfixed64 {
     }
 }
 
-#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Sfixed32(pub i32);
 
 impl Message for Sfixed32 {

--- a/pb-jelly/src/lib.rs
+++ b/pb-jelly/src/lib.rs
@@ -3,9 +3,6 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_possible_wrap)]
 
-#[macro_use]
-extern crate serde;
-
 use std::any::Any;
 use std::collections::BTreeMap;
 use std::default::Default;


### PR DESCRIPTION
I find it unlikely that anyone is depending on these impls and the serde dependency makes pb-jelly quite a bit slower to compile.

serde support entirely might go later as it's really a big hack (e.g. serde is turned on for all crates compiled in one protoc invocation if any of those files uses the option, unless crate_per_dir mode is on). It should be replaced by proper JSON protobuf support.