### PR TITLE
Fix codegen panic on messages containing nested `extend` blocks

### DIFF
--- a/pb-jelly-gen/src/codegen.rs
+++ b/pb-jelly-gen/src/codegen.rs
@@ -2019,11 +2019,6 @@ fn walk(proto: &FileDescriptorProto) -> WalkResult<'_> {
         }
 
         for (i, nested_extension) in proto.extension.iter().enumerate() {
-            // The field on `DescriptorProto` for nested extensions is `extension`
-            // (number 6); see google/protobuf/descriptor.proto. Previously this
-            // looked up `"extension_type"`, which does not exist and would panic
-            // (`Option::unwrap()` on `None`) whenever a message contained a
-            // nested `extend` block.
             let extfn = DescriptorProto::default()
                 .descriptor()
                 .unwrap()

--- a/pb-jelly-gen/src/codegen.rs
+++ b/pb-jelly-gen/src/codegen.rs
@@ -2019,10 +2019,15 @@ fn walk(proto: &FileDescriptorProto) -> WalkResult<'_> {
         }
 
         for (i, nested_extension) in proto.extension.iter().enumerate() {
+            // The field on `DescriptorProto` for nested extensions is `extension`
+            // (number 6); see google/protobuf/descriptor.proto. Previously this
+            // looked up `"extension_type"`, which does not exist and would panic
+            // (`Option::unwrap()` on `None`) whenever a message contained a
+            // nested `extend` block.
             let extfn = DescriptorProto::default()
                 .descriptor()
                 .unwrap()
-                .get_field("extension_type")
+                .get_field("extension")
                 .unwrap()
                 .number as i32;
             let mut scl2 = scl_prefix.clone();

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/lib.rs.expected
@@ -26,6 +26,7 @@
 pub mod bench;
 pub mod extensions;
 pub mod r#mod;
+pub mod nested_extensions;
 pub mod pbtest2;
 pub mod pbtest3;
 pub mod servicepb;

--- a/pb-test/gen/pb-jelly/proto_pbtest/src/nested_extensions.rs.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/src/nested_extensions.rs.expected
@@ -1,0 +1,189 @@
+// @generated, do not edit
+/// Regression test: a message containing a nested `extend` block.
+
+/// Previously, walking such a message in pb-jelly-gen panicked with
+/// `Option::unwrap() on a None value` because the codegen looked up the
+/// non-existent field name `"extension_type"` on `DescriptorProto` instead
+/// of the real field `"extension"` (number 6).
+#[derive(Clone, Debug, PartialEq)]
+pub struct Outer {
+  pub _extensions: ::pb_jelly::Unrecognized,
+}
+impl Outer {
+}
+impl ::std::default::Default for Outer {
+  fn default() -> Self {
+    Outer {
+      _extensions: ::pb_jelly::Unrecognized::default(),
+    }
+  }
+}
+::lazy_static::lazy_static! {
+  pub static ref Outer_default: Outer = Outer::default();
+}
+impl ::pb_jelly::Message for Outer {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "Outer",
+      full_name: "pbtest.Outer",
+      fields: &[
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0usize;
+    size += self._extensions.compute_size();
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    self._extensions.serialize(w)?;
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        100..=200 => {
+          self._extensions.gather(field_number, typ, &mut buf)?;
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for Outer {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+impl ::pb_jelly::extensions::Extensible for Outer {
+  fn _extensions(&self) -> &::pb_jelly::Unrecognized {
+    &self._extensions
+  }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Outer_Inner {
+  pub inner_field: ::std::option::Option<i32>,
+}
+impl Outer_Inner {
+  pub fn has_inner_field(&self) -> bool {
+    self.inner_field.is_some()
+  }
+  pub fn set_inner_field(&mut self, v: i32) {
+    self.inner_field = Some(v);
+  }
+  pub fn get_inner_field(&self) -> i32 {
+    self.inner_field.unwrap_or(0i32)
+  }
+}
+impl ::std::default::Default for Outer_Inner {
+  fn default() -> Self {
+    Outer_Inner {
+      inner_field: ::std::default::Default::default(),
+    }
+  }
+}
+::lazy_static::lazy_static! {
+  pub static ref Outer_Inner_default: Outer_Inner = Outer_Inner::default();
+}
+impl ::pb_jelly::Message for Outer_Inner {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "Outer_Inner",
+      full_name: "pbtest.Outer_Inner",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "inner_field",
+          full_name: "pbtest.Outer_Inner.inner_field",
+          index: 0,
+          number: 1,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0usize;
+    if let Some(ref val) = self.inner_field {
+      size += ::pb_jelly::helpers::compute_size_field::<i32>(val, 1, ::pb_jelly::wire_format::Type::Varint);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if let Some(ref val) = self.inner_field {
+      ::pb_jelly::helpers::serialize_field::<W, i32>(w, val, 1, ::pb_jelly::wire_format::Type::Varint)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          let val = ::pb_jelly::helpers::deserialize_known_length::<B, i32>(buf, typ, ::pb_jelly::wire_format::Type::Varint, "Outer_Inner", 1)?;
+          self.inner_field = Some(val);
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for Outer_Inner {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "inner_field" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.inner_field.get_or_insert_with(::std::default::Default::default))
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+
+pub const Outer_NESTED_SINGULAR_PRIMITIVE: ::pb_jelly::extensions::SingularExtension<Outer, i32> =
+  ::pb_jelly::extensions::SingularExtension::new(
+    101,
+    ::pb_jelly::wire_format::Type::Varint,
+    "nested_singular_primitive",
+    || ::std::default::Default::default(),
+  );
+
+
+pub const Outer_NESTED_REPEATED_MESSAGE: ::pb_jelly::extensions::RepeatedExtension<Outer, Outer_Inner> =
+  ::pb_jelly::extensions::RepeatedExtension::new(
+    102,
+    ::pb_jelly::wire_format::Type::LengthDelimited,
+    "nested_repeated_message",
+  );
+
+

--- a/pb-test/proto/packages/pbtest/nested_extensions.proto
+++ b/pb-test/proto/packages/pbtest/nested_extensions.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+package pbtest;
+
+// Regression test: a message containing a nested `extend` block.
+//
+// Previously, walking such a message in pb-jelly-gen panicked with
+// `Option::unwrap() on a None value` because the codegen looked up the
+// non-existent field name `"extension_type"` on `DescriptorProto` instead
+// of the real field `"extension"` (number 6).
+message Outer {
+    extensions 100 to 200;
+
+    message Inner {
+        optional int32 inner_field = 1;
+    }
+
+    extend Outer {
+        optional int32 nested_singular_primitive = 101;
+        repeated Inner nested_repeated_message = 102;
+    }
+}


### PR DESCRIPTION
## Summary
`pb-jelly-gen`'s message walker (`_walk_message` in `codegen.rs`) panicked with `called Option::unwrap() on a None value` whenever it encountered a message containing a nested `extend` block.

The walker was looking up a field named `"extension_type"` on `DescriptorProto`, but the actual field for nested extensions is named `"extension"` (number 6) — see [`google/protobuf/descriptor.proto`](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto). `get_field("extension_type")` returned `None`, and the immediate `.unwrap()` panicked.

The file-level walker (`_walk_file`) already used the correct field name, so top-level `extend` blocks were unaffected. Only nested extends triggered the bug.

## Why this surfaced now
The bug was dormant because no existing `pb-test` fixture exercised a nested `extend` block. It fires on real-world protos — most notably upstream protobuf v29's [`google/protobuf/sample_messages_edition.proto`](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/sample_messages_edition.proto), which nests extends inside `MessageSetCorrectExtension*`. Anyone pulling protobuf v29 protos into a `pb-jelly-gen` build hits the panic immediately.

## Test plan
- [x] `cd pb-test/pb_test_gen && cargo run` — codegen succeeds
- [x] `cd pb-test && cargo test` — integration tests pass
- [x] Confirmed reverting only the one-line fix re-introduces the
      panic on the new fixture, proving the test catches the
      regression.