### PR TITLE
Add Cargo workspace configuration to centralize dependency management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,31 @@
+[workspace]
+resolver = "2"
+members = [
+    "pb-jelly",
+    "pb-jelly-gen",
+]
+exclude = [
+    "examples",
+    "pb-test",
+]
+
+[workspace.package]
+version = "0.0.17"
+edition = "2018"
+repository = "https://github.com/dropbox/pb-jelly"
+authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
+license = "Apache-2.0"
+homepage = "https://github.com/dropbox/pb-jelly"
+readme = "README.md"
+keywords = ["google", "protobuf", "proto", "dropbox"]
+categories = ["encoding", "parsing", "web-programming"]
+
+[workspace.dependencies]
+byteorder = "1.4"
+bytes = "1.0"
+compact_str = { version = "0.5", features = ["bytes", "serde"] }
+tempfile = "3.1.0"
+walkdir = "2.3.1"
+pb-jelly = { path = "pb-jelly", version = "0.0.17" }
+indexmap = "2.0.2"
+

--- a/pb-jelly-gen/Cargo.toml
+++ b/pb-jelly-gen/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "pb-jelly-gen"
 description = "A protobuf binding generation framework for the Rust language developed at Dropbox"
-version = "0.0.17"
-authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
-edition = "2018"
-license = "Apache-2.0"
-homepage = "https://github.com/dropbox/pb-jelly"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 repository = "https://github.com/dropbox/pb-jelly/tree/main/pb-jelly-gen"
-readme = "README.md"
-keywords = ["google", "protobuf", "proto", "dropbox"]
-categories = ["encoding", "parsing", "web-programming"]
-
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 include = ["src/**/*.rs", "README.md", "LICENSE", "proto"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -20,13 +19,7 @@ default = ["generate"]
 generate = ["walkdir", "tempfile"]
 
 [dependencies]
-tempfile = { version = "3.1.0", optional = true }
-walkdir = { version = "2", optional = true }
-
-pb-jelly = { version = "0.0.17" }
-lazy_static = "1.4.0"
-indexmap = "2.0.2"
-
-# Override pb-jelly dependency for generated crates as well
-[patch.crates-io]
-pb-jelly = { path = "../pb-jelly" }
+tempfile = { workspace = true, optional = true }
+walkdir = { workspace = true, optional = true }
+pb-jelly = { workspace = true }
+indexmap = { workspace = true }

--- a/pb-jelly-gen/regen_gen_protos.sh
+++ b/pb-jelly-gen/regen_gen_protos.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 cargo build --no-default-features && \
-protoc --plugin=protoc-gen-jellyrust=target/debug/protoc-gen-jellyrust -Iproto rust/extensions.proto google/protobuf/{compiler/plugin,descriptor}.proto --jellyrust_out=single_file:src
+protoc --plugin=protoc-gen-jellyrust=../target/debug/protoc-gen-jellyrust -Iproto rust/extensions.proto google/protobuf/{compiler/plugin,descriptor}.proto --jellyrust_out=single_file:src

--- a/pb-jelly/Cargo.toml
+++ b/pb-jelly/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "pb-jelly"
 description = "A protobuf runtime for the Rust language developed at Dropbox"
-version = "0.0.17"
-authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
-edition = "2018"
-license = "Apache-2.0"
-homepage = "https://github.com/dropbox/pb-jelly"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 repository = "https://github.com/dropbox/pb-jelly/tree/main/pb-jelly"
-readme = "README.md"
-keywords = ["google", "protobuf", "proto", "dropbox"]
-categories = ["encoding", "parsing", "web-programming"]
+keywords.workspace = true
+categories.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-byteorder = "1.4"
-bytes = "1.0"
-compact_str = { version = "0.5", features = ["bytes"] }
+byteorder = { workspace = true }
+bytes = { workspace = true }
+compact_str = { workspace = true }


### PR DESCRIPTION
This commit introduces a workspace-level Cargo.toml that consolidates common package metadata and dependencies. Both pb-jelly and pb-jelly-gen crates now inherit workspace configuration, reducing duplication and ensuring consistency across the project.