### PR TITLE
rename examples_gen package from `pb-test/pb_test_gen`

### DIFF
--- a/pb-test/pb_test_gen/Cargo.toml
+++ b/pb-test/pb_test_gen/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples_gen"
+name = "pb_test_gen"
 version = "0.1.0"
 authors = ["Parker Timmerman <parkertimmerman@dropbox.com>"]
 edition = "2018"


### PR DESCRIPTION
We already have examples_gen package in examples_gen package in `examples/examples_gen`

Having packages with the same name might break some automated tools