### PR TITLE
Add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,49 @@
+name: Publish crates
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    environment: crates-io-publish
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Dry run pb-jelly
+        run: cargo +stable publish -p pb-jelly --dry-run
+
+      - name: Dry run pb-jelly-gen
+        run: cargo +stable publish -p pb-jelly-gen --dry-run
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish pb-jelly
+        run: cargo +stable publish -p pb-jelly
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Wait for crates.io index
+        run: sleep 30
+
+      - name: Publish pb-jelly-gen
+        run: cargo +stable publish -p pb-jelly-gen
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: crates-publish
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -12,6 +16,7 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: crates-io-publish
 
     permissions:
@@ -41,7 +46,7 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Wait for crates.io index
-        run: sleep 30
+        run: sleep 60
 
       - name: Publish pb-jelly-gen
         run: cargo +stable publish -p pb-jelly-gen


### PR DESCRIPTION
Add a GitHub Actions workflow that publishes pb-jelly and pb-jelly-gen to crates.io on release, using OIDC trusted publishing for auth.

The goal is to auto-publish when we tag releases.