### PR TITLE
Bump versions to 0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Unreleased
 ... everything has been released!
 
+# 0.0.18
+### June 24, 2026
+* Fix codegen panic on messages containing nested `extend` blocks (#181)
+* Update `pb-jelly-gen` to use `std::sync::LazyLock` (#182)
+* Add Cargo workspace configuration to centralize dependency management (#183)
+* Rename `examples_gen` package from `pb-test/pb_test_gen` (#184)
+* Add crates.io publish workflow (#185)
+
 # 0.0.17
 ### Nov 20, 2024
 * Add read-only support for proto2 extension fields (#163, #170)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.0.17"
+version = "0.0.18"
 edition = "2018"
 repository = "https://github.com/dropbox/pb-jelly"
 authors = ["Rajat Goel <rajat@dropbox.com>", "Nipunn Koorapati <nipunn@dropbox.com>", "Parker Timmerman <parkertimmerman@dropbox.com>"]
@@ -26,6 +26,6 @@ bytes = "1.0"
 compact_str = { version = "0.5", features = ["bytes", "serde"] }
 tempfile = "3.1.0"
 walkdir = "2.3.1"
-pb-jelly = { path = "pb-jelly", version = "0.0.17" }
+pb-jelly = { path = "pb-jelly", version = "0.0.18" }
 indexmap = "2.0.2"
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ There are only two crates you'll need: `pb-jelly` and `pb-jelly-gen`. <br />
 Contains all of the important traits and structs that power our generated code, e.g. `Message` and `Lazy`. Include this as a dependency, e.g.
 ```
 [dependencies]
-pb-jelly = "0.0.17"
+pb-jelly = "0.0.18"
 ```
 
 ##### `pb-jelly-gen`
@@ -75,7 +75,7 @@ You'll need to add a generation crate (see `examples_gen` for an example)
 Include `pb-jelly-gen` as a dependency of your generation crate, and `cargo run` to invoke protoc for you.
 ```
 [dependencies]
-pb-jelly-gen = "0.0.17"
+pb-jelly-gen = "0.0.18"
 ```
 
 Eventually, we hope to eliminate the need for a generation crate, and simply have generation occur

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 bytes = "1.0"
 compact_str = "0.5"
-pb-jelly = "0.0.17"
+pb-jelly = "0.0.18"
 proto_box_it = { path = "gen/rust/proto/proto_box_it" }
 proto_custom_type = { path = "gen/rust/proto/proto_custom_type" }
 proto_linked_list = { path = "gen/rust/proto/proto_linked_list" }

--- a/examples/examples_gen/Cargo.toml
+++ b/examples/examples_gen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.17"  # If copying this example - use this
+#pb-jelly-gen = "0.0.18"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }
 
 [patch.crates-io]

--- a/pb-jelly-gen/README.md
+++ b/pb-jelly-gen/README.md
@@ -26,7 +26,7 @@ Add this crate as a dependency in your `Cargo.toml` and then call `gen_protos`:
 ##### `Cargo.toml`
 ```
 [dependencies]
-pb-jelly-gen = "0.0.17"
+pb-jelly-gen = "0.0.18"
 ```
 
 ##### `main.rs`

--- a/pb-jelly-gen/src/codegen.rs
+++ b/pb-jelly-gen/src/codegen.rs
@@ -2564,7 +2564,7 @@ impl<'a> Context<'a> {
             }
 
             let mut versions: IndexMap<&str, String> = IndexMap::new();
-            versions.insert("pb-jelly", "version = \"0.0.17\"".to_string());
+            versions.insert("pb-jelly", "version = \"0.0.18\"".to_string());
             versions.insert("serde", "version = \"1.0\"".to_string());
             versions.insert("serde_derive", "version = \"1.0\"".to_string());
             versions.insert("bytes", "version = \"1.0\"".to_string());

--- a/pb-jelly-gen/src/lib.rs
+++ b/pb-jelly-gen/src/lib.rs
@@ -8,7 +8,7 @@
 //! You can include `pb-jelly-gen` in your Cargo project, by including it as a `[build-dependency]` in your `Cargo.toml`
 //! ```toml
 //! [build-dependencies]
-//! pb-jelly-gen = "0.0.17"
+//! pb-jelly-gen = "0.0.18"
 //! ```
 //!
 //! Then from a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) script, use either the `GenProtos` builder struct,

--- a/pb-jelly/README.md
+++ b/pb-jelly/README.md
@@ -10,7 +10,7 @@ include this crate as a dependency in your `Cargo.toml`.
 ##### `Cargo.toml`
 ```
 [dependencies]
-pb-jelly = "0.0.17"
+pb-jelly = "0.0.18"
 ```
 
 Then in the general case, all you'll need to use in your code is the `Message` trait this crate defines, e.g.

--- a/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_google/Cargo.toml.expected
@@ -5,4 +5,4 @@ version = "0.0.1"
 edition = "2018"
 
 [dependencies]
-pb-jelly = { version = "0.0.17" }
+pb-jelly = { version = "0.0.18" }

--- a/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_nopackage/Cargo.toml.expected
@@ -5,4 +5,4 @@ version = "0.0.1"
 edition = "2018"
 
 [dependencies]
-pb-jelly = { version = "0.0.17" }
+pb-jelly = { version = "0.0.18" }

--- a/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
+++ b/pb-test/gen/pb-jelly/proto_pbtest/Cargo.toml.expected
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 bytes = { version = "1.0" }
 compact_str = { features=["bytes"], version = "0.5" }
-pb-jelly = { version = "0.0.17" }
+pb-jelly = { version = "0.0.18" }
 proto_google = { path = "../proto_google" }

--- a/pb-test/pb_test_gen/Cargo.toml
+++ b/pb-test/pb_test_gen/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-#pb-jelly-gen = "0.0.17"  # If copying this example - use this
+#pb-jelly-gen = "0.0.18"  # If copying this example - use this
 pb-jelly-gen = { path = "../../pb-jelly-gen" }
 
 # only used when benchmarking PROST!


### PR DESCRIPTION
Notable changes since 0.0.17:
- Fix codegen panic on messages containing nested `extend` blocks (#181)
- Update `pb-jelly-gen` to use `std::sync::LazyLock` (#182)
- Add Cargo workspace configuration to centralize dependency management (#183)
- Rename `examples_gen` package from `pb-test/pb_test_gen` (#184)
- Add crates.io publish workflow (#185)